### PR TITLE
Add Gemini support and harden controller selector matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It exposes an MCP server so tools like Codex can:
 ## Supported sites
 **Supported**
 - `chatgpt.com`
+- `gemini.google.com` (best-effort selectors)
 
 **Planned**
 - `claude.ai`
@@ -78,8 +79,8 @@ codex mcp list
 If you already had Codex open, restart it (or start a new session) so it reloads MCP server config.
 
 ## How to use (practical)
-- **Use ChatGPT normally (manual):** write a plan/spec in the UI, then in Codex call `agentify_read_page` to pull the transcript into your workflow.
-- **Drive ChatGPT from Codex:** call `agentify_ensure_ready`, then `agentify_query` with a `prompt`. Use a stable `key` per project to keep parallel jobs isolated.
+- **Use ChatGPT/Gemini normally (manual):** write a plan/spec in the UI, then in Codex call `agentify_read_page` to pull the transcript into your workflow.
+- **Drive ChatGPT/Gemini from Codex:** call `agentify_ensure_ready`, then `agentify_query` with a `prompt`. Use a stable `key` per project to keep parallel jobs isolated.
 - **Parallel jobs:** create/ensure a tab per project with `agentify_tab_create(key: ...)`, then use that `key` for `agentify_query`, `agentify_read_page`, and `agentify_download_images`.
 - **Upload files:** pass local paths via `attachments` to `agentify_query` (best-effort; depends on the site UI).
 - **Generate/download images:** ask for images via `agentify_query` (then call `agentify_download_images`), or use `agentify_image_gen` (prompt + download).
@@ -129,6 +130,7 @@ Agentify Desktop can optionally run a local “orchestrator” that watches a Ch
 
 ## Limitations / robustness notes
 - **File upload selectors:** `input[type=file]` selection is best-effort; if ChatGPT changes the upload flow, update `selectors.json` or `~/.agentify-desktop/selectors.override.json`.
+- **Gemini selectors:** Gemini support uses best-effort DOM selectors; if Google updates the UI, override selectors in `~/.agentify-desktop/selectors.override.json`.
 - **Completion detection:** waiting for “stop generating” to disappear + text stability works well, but can mis-detect on very long outputs or intermittent streaming pauses.
 - **Image downloads:** prefers `<img>` elements in the latest assistant message; some UI modes may render images via nonstandard elements.
 - **Parallelism model:** “tabs” are separate windows; they can run in parallel without stealing focus unless a human check is required.

--- a/chatgpt-controller.mjs
+++ b/chatgpt-controller.mjs
@@ -89,11 +89,17 @@ export class ChatGPTController {
         || /log in|sign in|continue with/i.test(bodyText);
 
       const promptVisible = (() => {
-        const el = document.querySelector(${JSON.stringify(this.selectors.promptTextarea)});
-        if (!el) return false;
-        const r = el.getBoundingClientRect();
-        const style = window.getComputedStyle(el);
-        return r.width > 0 && r.height > 0 && style.visibility !== 'hidden' && style.display !== 'none';
+        const candidates = Array.from(document.querySelectorAll(${JSON.stringify(this.selectors.promptTextarea)}));
+        const el = candidates.find((n) => {
+          const r = n.getBoundingClientRect();
+          const style = window.getComputedStyle(n);
+          const visible = r.width > 0 && r.height > 0 && style.visibility !== 'hidden' && style.display !== 'none';
+          if (!visible) return false;
+          if (n.matches('textarea')) return !n.disabled && !n.readOnly;
+          if (n.isContentEditable) return true;
+          return true;
+        });
+        return !!el;
       })();
 
       const blocked = hasTurnstile || hasArkose || hasVerifyButton || looks403 || (loginLike && !promptVisible);
@@ -206,7 +212,16 @@ export class ChatGPTController {
   async #typePrompt(prompt) {
     const sel = JSON.stringify(this.selectors.promptTextarea);
     const ok = await this.#eval(`(() => {
-      const el = document.querySelector(${sel});
+      const candidates = Array.from(document.querySelectorAll(${sel}));
+      const el = candidates.find((n) => {
+        const r = n.getBoundingClientRect();
+        const style = window.getComputedStyle(n);
+        const visible = r.width > 0 && r.height > 0 && style.visibility !== 'hidden' && style.display !== 'none';
+        if (!visible) return false;
+        if (n.matches('textarea')) return !n.disabled && !n.readOnly;
+        if (n.isContentEditable) return true;
+        return true;
+      }) || candidates[0];
       if (!el) return { ok:false, error:'missing_prompt_textarea' };
       el.focus();
       const r = el.getBoundingClientRect();
@@ -238,9 +253,18 @@ export class ChatGPTController {
     const sendSel = JSON.stringify(this.selectors.sendButton);
     const stopSel = JSON.stringify(this.selectors.stopButton);
     const res = await this.#eval(`(() => {
-      const stop = document.querySelector(${stopSel});
+      const stop = Array.from(document.querySelectorAll(${stopSel})).find((n) => {
+        const r = n.getBoundingClientRect();
+        const style = window.getComputedStyle(n);
+        return r.width > 0 && r.height > 0 && style.visibility !== 'hidden' && style.display !== 'none';
+      });
       if (stop) return { ok:false, error:'already_generating' };
-      const btn = document.querySelector(${sendSel});
+      const btn = Array.from(document.querySelectorAll(${sendSel})).find((n) => {
+        const r = n.getBoundingClientRect();
+        const style = window.getComputedStyle(n);
+        if (!(r.width > 0 && r.height > 0 && style.visibility !== 'hidden' && style.display !== 'none')) return false;
+        return !n.disabled;
+      });
       if (!btn) return { ok:false, error:'missing_send_button' };
       if (btn.disabled) return { ok:false, error:'send_button_disabled' };
       const r = btn.getBoundingClientRect();

--- a/popup-policy.mjs
+++ b/popup-policy.mjs
@@ -43,8 +43,9 @@ export function isAllowedAuthPopupUrl(url, { vendorId = 'chatgpt' } = {}) {
   const host = normalizeHostname(u.hostname);
   if (!host) return false;
 
-  // v0.1 supports ChatGPT. Keep behavior conservative for other vendors.
-  if (String(vendorId || 'chatgpt') !== 'chatgpt') return false;
+  // Keep behavior conservative: allow only vendors where we explicitly support auth popups.
+  const vendor = String(vendorId || 'chatgpt').trim().toLowerCase();
+  if (!['chatgpt', 'gemini'].includes(vendor)) return false;
 
   return CHATGPT_AUTH_HOST_ALLOWLIST.some((pattern) => hostMatchesPattern(host, pattern));
 }
@@ -57,4 +58,3 @@ export function shouldAllowPopup({
   if (!allowAuthPopups) return false;
   return isAllowedAuthPopupUrl(url, { vendorId });
 }
-

--- a/selectors.json
+++ b/selectors.json
@@ -1,8 +1,7 @@
 {
-  "promptTextarea": "#prompt-textarea",
-  "sendButton": "button[data-testid=\"send-button\"], button[aria-label=\"Send prompt\"], button[aria-label=\"Send\"]",
-  "stopButton": "button[data-testid=\"stop-button\"], button[aria-label=\"Stop generating\"], button[aria-label=\"Stop\"]",
-  "assistantMessage": "[data-message-author-role=\"assistant\"]",
+  "promptTextarea": "#prompt-textarea, rich-textarea .ql-editor[contenteditable=\"true\"], div.ql-editor[contenteditable=\"true\"], div[contenteditable=\"true\"][aria-label*=\"prompt\" i], textarea[aria-label*=\"prompt\" i]",
+  "sendButton": "button[data-testid=\"send-button\"], button[aria-label=\"Send prompt\"], button[aria-label=\"Send\"], button[aria-label*=\"Send message\" i], button[aria-label*=\"Submit\" i]",
+  "stopButton": "button[data-testid=\"stop-button\"], button[aria-label=\"Stop generating\"], button[aria-label=\"Stop\"], button[aria-label*=\"Stop response\" i]",
+  "assistantMessage": "[data-message-author-role=\"assistant\"], model-response, .model-response-text, [data-test-id=\"model-response\"], [data-response-author=\"model\"]",
   "composerRoot": "form, main"
 }
-

--- a/tests/popup-policy.test.mjs
+++ b/tests/popup-policy.test.mjs
@@ -11,6 +11,10 @@ test('popup-policy: allows OpenAI auth popup URL for chatgpt vendor', () => {
   assert.equal(isAllowedAuthPopupUrl('https://auth.openai.com/u/login', { vendorId: 'chatgpt' }), true);
 });
 
+test('popup-policy: allows Google auth popup URL for gemini vendor', () => {
+  assert.equal(isAllowedAuthPopupUrl('https://accounts.google.com/signin/v2/identifier', { vendorId: 'gemini' }), true);
+});
+
 test('popup-policy: blocks non-https popup URL', () => {
   assert.equal(isAllowedAuthPopupUrl('http://accounts.google.com/signin/v2/identifier', { vendorId: 'chatgpt' }), false);
 });
@@ -29,4 +33,3 @@ test('popup-policy: can globally disable auth popups via setting', () => {
     false
   );
 });
-

--- a/vendors.json
+++ b/vendors.json
@@ -7,6 +7,12 @@
       "status": "supported"
     },
     {
+      "id": "gemini",
+      "name": "Gemini",
+      "url": "https://gemini.google.com/",
+      "status": "supported"
+    },
+    {
       "id": "claude",
       "name": "Claude",
       "url": "https://claude.ai/",


### PR DESCRIPTION
## Summary
Adds first-pass Gemini support in Agentify Desktop and hardens selector handling to reduce UI brittleness.

## What changed
- Added `gemini.google.com` as a supported vendor (`vendors.json`).
- Expanded selector fallbacks for Gemini composer/send/stop/response surfaces (`selectors.json`).
- Allowed auth popups for `gemini` under the same constrained HTTPS auth-domain allowlist (`popup-policy.mjs`).
- Hardened controller element selection:
  - pick first visible/usable prompt element instead of first DOM match
  - pick first visible/enabled send button instead of first DOM match
  - ignore hidden stop buttons in send-path checks
- Added/updated tests for popup policy (`tests/popup-policy.test.mjs`).

## Validation
- Ran `npm test` in `desktop/`.
- Result: 46/46 passing.

## Notes
This is best-effort support; Gemini UI changes may still require selector overrides via `~/.agentify-desktop/selectors.override.json`.
