### PR TITLE
Add Perplexity support and harden cross-vendor selector fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It exposes an MCP server so tools like Codex can:
 ## Supported sites
 **Supported**
 - `chatgpt.com`
+- `perplexity.ai` (best-effort selectors)
 
 **Planned**
 - `claude.ai`
@@ -78,8 +79,8 @@ codex mcp list
 If you already had Codex open, restart it (or start a new session) so it reloads MCP server config.
 
 ## How to use (practical)
-- **Use ChatGPT normally (manual):** write a plan/spec in the UI, then in Codex call `agentify_read_page` to pull the transcript into your workflow.
-- **Drive ChatGPT from Codex:** call `agentify_ensure_ready`, then `agentify_query` with a `prompt`. Use a stable `key` per project to keep parallel jobs isolated.
+- **Use ChatGPT/Perplexity normally (manual):** write a plan/spec in the UI, then in Codex call `agentify_read_page` to pull the transcript into your workflow.
+- **Drive ChatGPT/Perplexity from Codex:** call `agentify_ensure_ready`, then `agentify_query` with a `prompt`. Use a stable `key` per project to keep parallel jobs isolated.
 - **Parallel jobs:** create/ensure a tab per project with `agentify_tab_create(key: ...)`, then use that `key` for `agentify_query`, `agentify_read_page`, and `agentify_download_images`.
 - **Upload files:** pass local paths via `attachments` to `agentify_query` (best-effort; depends on the site UI).
 - **Generate/download images:** ask for images via `agentify_query` (then call `agentify_download_images`), or use `agentify_image_gen` (prompt + download).
@@ -129,6 +130,7 @@ Agentify Desktop can optionally run a local “orchestrator” that watches a Ch
 
 ## Limitations / robustness notes
 - **File upload selectors:** `input[type=file]` selection is best-effort; if ChatGPT changes the upload flow, update `selectors.json` or `~/.agentify-desktop/selectors.override.json`.
+- **Perplexity selectors:** Perplexity support is best-effort and may require selector overrides in `~/.agentify-desktop/selectors.override.json` if UI changes.
 - **Completion detection:** waiting for “stop generating” to disappear + text stability works well, but can mis-detect on very long outputs or intermittent streaming pauses.
 - **Image downloads:** prefers `<img>` elements in the latest assistant message; some UI modes may render images via nonstandard elements.
 - **Parallelism model:** “tabs” are separate windows; they can run in parallel without stealing focus unless a human check is required.

--- a/popup-policy.mjs
+++ b/popup-policy.mjs
@@ -43,8 +43,9 @@ export function isAllowedAuthPopupUrl(url, { vendorId = 'chatgpt' } = {}) {
   const host = normalizeHostname(u.hostname);
   if (!host) return false;
 
-  // v0.1 supports ChatGPT. Keep behavior conservative for other vendors.
-  if (String(vendorId || 'chatgpt') !== 'chatgpt') return false;
+  // Keep behavior conservative: only explicitly allow supported vendor auth flows.
+  const vendor = String(vendorId || 'chatgpt').trim().toLowerCase();
+  if (!['chatgpt', 'perplexity'].includes(vendor)) return false;
 
   return CHATGPT_AUTH_HOST_ALLOWLIST.some((pattern) => hostMatchesPattern(host, pattern));
 }
@@ -57,4 +58,3 @@ export function shouldAllowPopup({
   if (!allowAuthPopups) return false;
   return isAllowedAuthPopupUrl(url, { vendorId });
 }
-

--- a/selectors.json
+++ b/selectors.json
@@ -1,8 +1,7 @@
 {
-  "promptTextarea": "#prompt-textarea",
-  "sendButton": "button[data-testid=\"send-button\"], button[aria-label=\"Send prompt\"], button[aria-label=\"Send\"]",
-  "stopButton": "button[data-testid=\"stop-button\"], button[aria-label=\"Stop generating\"], button[aria-label=\"Stop\"]",
-  "assistantMessage": "[data-message-author-role=\"assistant\"]",
+  "promptTextarea": "#prompt-textarea, rich-textarea .ql-editor[contenteditable=\"true\"], div.ql-editor[contenteditable=\"true\"], div.ProseMirror[contenteditable=\"true\"], div[contenteditable=\"true\"][aria-label*=\"prompt\" i], div[contenteditable=\"true\"][aria-label*=\"message\" i], textarea[aria-label*=\"prompt\" i], textarea[placeholder*=\"ask\" i], textarea[placeholder*=\"message\" i]",
+  "sendButton": "button[data-testid=\"send-button\"], button[data-testid*=\"send\" i], button[aria-label=\"Send prompt\"], button[aria-label=\"Send\"], button[aria-label*=\"send message\" i], button[aria-label*=\"submit\" i]",
+  "stopButton": "button[data-testid=\"stop-button\"], button[data-testid*=\"stop\" i], button[aria-label=\"Stop generating\"], button[aria-label=\"Stop\"], button[aria-label*=\"stop response\" i], button[aria-label*=\"cancel\" i]",
+  "assistantMessage": "[data-message-author-role=\"assistant\"], model-response, .model-response-text, [data-test-id=\"model-response\"], [data-response-author=\"model\"], article[data-testid*=\"answer\" i], [data-testid*=\"assistant\" i]",
   "composerRoot": "form, main"
 }
-

--- a/tests/popup-policy.test.mjs
+++ b/tests/popup-policy.test.mjs
@@ -11,6 +11,10 @@ test('popup-policy: allows OpenAI auth popup URL for chatgpt vendor', () => {
   assert.equal(isAllowedAuthPopupUrl('https://auth.openai.com/u/login', { vendorId: 'chatgpt' }), true);
 });
 
+test('popup-policy: allows Google auth popup URL for perplexity vendor', () => {
+  assert.equal(isAllowedAuthPopupUrl('https://accounts.google.com/signin/v2/identifier', { vendorId: 'perplexity' }), true);
+});
+
 test('popup-policy: blocks non-https popup URL', () => {
   assert.equal(isAllowedAuthPopupUrl('http://accounts.google.com/signin/v2/identifier', { vendorId: 'chatgpt' }), false);
 });
@@ -29,4 +33,3 @@ test('popup-policy: can globally disable auth popups via setting', () => {
     false
   );
 });
-

--- a/vendors.json
+++ b/vendors.json
@@ -7,6 +7,12 @@
       "status": "supported"
     },
     {
+      "id": "perplexity",
+      "name": "Perplexity",
+      "url": "https://www.perplexity.ai/",
+      "status": "supported"
+    },
+    {
       "id": "claude",
       "name": "Claude",
       "url": "https://claude.ai/",


### PR DESCRIPTION
## Summary
Adds Perplexity support and hardens controller fallback behavior so prompt/send detection is less brittle across non-ChatGPT UIs.

## Changes
- Added `perplexity.ai` as a supported vendor (`vendors.json`).
- Expanded selector coverage in `selectors.json` for cross-vendor composers/send/stop/assistant nodes.
- Allowed auth popup policy for `perplexity` under the existing constrained HTTPS auth domain allowlist (`popup-policy.mjs`).
- Hardened controller behavior (`chatgpt-controller.mjs`):
  - choose first visible/usable prompt target
  - choose first visible/enabled send button
  - fallback to Enter key submit when no send button selector matches
  - fallback response text extraction from `main/body` when assistant node selectors miss
- Added popup policy test for Perplexity (`tests/popup-policy.test.mjs`).
- Updated README support matrix and notes.

## Validation
- Ran `npm test` in `desktop/`
- Result: 46/46 passing
