### PR TITLE
Add Claude vendor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ It exposes an MCP server so tools like Codex can:
 **Supported**
 - `chatgpt.com`
 - `perplexity.ai` (best-effort selectors)
+- `claude.ai` (best-effort selectors)
 
 **Planned**
-- `claude.ai`
 - `grok.com`
 - `aistudio.google.com`
 
@@ -79,8 +79,8 @@ codex mcp list
 If you already had Codex open, restart it (or start a new session) so it reloads MCP server config.
 
 ## How to use (practical)
-- **Use ChatGPT/Perplexity normally (manual):** write a plan/spec in the UI, then in Codex call `agentify_read_page` to pull the transcript into your workflow.
-- **Drive ChatGPT/Perplexity from Codex:** call `agentify_ensure_ready`, then `agentify_query` with a `prompt`. Use a stable `key` per project to keep parallel jobs isolated.
+- **Use ChatGPT/Perplexity/Claude normally (manual):** write a plan/spec in the UI, then in Codex call `agentify_read_page` to pull the transcript into your workflow.
+- **Drive ChatGPT/Perplexity/Claude from Codex:** call `agentify_ensure_ready`, then `agentify_query` with a `prompt`. Use a stable `key` per project to keep parallel jobs isolated.
 - **Parallel jobs:** create/ensure a tab per project with `agentify_tab_create(key: ...)`, then use that `key` for `agentify_query`, `agentify_read_page`, and `agentify_download_images`.
 - **Upload files:** pass local paths via `attachments` to `agentify_query` (best-effort; depends on the site UI).
 - **Generate/download images:** ask for images via `agentify_query` (then call `agentify_download_images`), or use `agentify_image_gen` (prompt + download).

--- a/popup-policy.mjs
+++ b/popup-policy.mjs
@@ -45,7 +45,7 @@ export function isAllowedAuthPopupUrl(url, { vendorId = 'chatgpt' } = {}) {
 
   // Keep behavior conservative: only explicitly allow supported vendor auth flows.
   const vendor = String(vendorId || 'chatgpt').trim().toLowerCase();
-  if (!['chatgpt', 'perplexity'].includes(vendor)) return false;
+  if (!['chatgpt', 'perplexity', 'claude'].includes(vendor)) return false;
 
   return CHATGPT_AUTH_HOST_ALLOWLIST.some((pattern) => hostMatchesPattern(host, pattern));
 }

--- a/selectors.json
+++ b/selectors.json
@@ -2,6 +2,6 @@
   "promptTextarea": "#prompt-textarea, rich-textarea .ql-editor[contenteditable=\"true\"], div.ql-editor[contenteditable=\"true\"], div.ProseMirror[contenteditable=\"true\"], div[contenteditable=\"true\"][aria-label*=\"prompt\" i], div[contenteditable=\"true\"][aria-label*=\"message\" i], textarea[aria-label*=\"prompt\" i], textarea[placeholder*=\"ask\" i], textarea[placeholder*=\"message\" i]",
   "sendButton": "button[data-testid=\"send-button\"], button[data-testid*=\"send\" i], button[aria-label=\"Send prompt\"], button[aria-label=\"Send\"], button[aria-label*=\"send message\" i], button[aria-label*=\"submit\" i]",
   "stopButton": "button[data-testid=\"stop-button\"], button[data-testid*=\"stop\" i], button[aria-label=\"Stop generating\"], button[aria-label=\"Stop\"], button[aria-label*=\"stop response\" i], button[aria-label*=\"cancel\" i]",
-  "assistantMessage": "[data-message-author-role=\"assistant\"], model-response, .model-response-text, [data-test-id=\"model-response\"], [data-response-author=\"model\"], article[data-testid*=\"answer\" i], [data-testid*=\"assistant\" i]",
+  "assistantMessage": "[data-message-author-role=\"assistant\"], model-response, .model-response-text, [data-test-id=\"model-response\"], [data-response-author=\"model\"], article[data-testid*=\"answer\" i], [data-testid*=\"assistant\" i], [data-testid=\"chat-message\"], [data-is-assistant=\"true\"]",
   "composerRoot": "form, main"
 }

--- a/tests/popup-policy.test.mjs
+++ b/tests/popup-policy.test.mjs
@@ -15,6 +15,10 @@ test('popup-policy: allows Google auth popup URL for perplexity vendor', () => {
   assert.equal(isAllowedAuthPopupUrl('https://accounts.google.com/signin/v2/identifier', { vendorId: 'perplexity' }), true);
 });
 
+test('popup-policy: allows Google auth popup URL for claude vendor', () => {
+  assert.equal(isAllowedAuthPopupUrl('https://accounts.google.com/signin/v2/identifier', { vendorId: 'claude' }), true);
+});
+
 test('popup-policy: blocks non-https popup URL', () => {
   assert.equal(isAllowedAuthPopupUrl('http://accounts.google.com/signin/v2/identifier', { vendorId: 'chatgpt' }), false);
 });

--- a/vendors.json
+++ b/vendors.json
@@ -16,7 +16,7 @@
       "id": "claude",
       "name": "Claude",
       "url": "https://claude.ai/",
-      "status": "planned"
+      "status": "supported"
     },
     {
       "id": "grok",


### PR DESCRIPTION
## Summary
Adds Claude as a supported vendor and extends selector/popup coverage for Claude login and responses.

## Changes
- Marked `claude.ai` as `supported` in `vendors.json`.
- Extended assistant response selector coverage with additional Claude-like message selectors.
- Enabled auth popup policy for `claude` vendor in `popup-policy.mjs`.
- Added popup-policy test for Claude.
- Updated README support matrix and usage wording.

## Validation
- Ran `npm test` in `desktop/`
- Result: 47/47 passing
