### PR TITLE
Add Google AI Studio vendor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ It exposes an MCP server so tools like Codex can:
 - `chatgpt.com`
 - `perplexity.ai` (best-effort selectors)
 - `claude.ai` (best-effort selectors)
+- `aistudio.google.com/prompts/new_chat` (best-effort selectors)
 
 **Planned**
 - `grok.com`
-- `aistudio.google.com`
 
 ## CAPTCHA policy (human-in-the-loop)
 Agentify Desktop does **not** attempt to bypass CAPTCHAs or use third-party solvers. If a human verification appears, the app pauses automation, brings the relevant window to the front, and waits for you to complete the check manually.
@@ -79,8 +79,8 @@ codex mcp list
 If you already had Codex open, restart it (or start a new session) so it reloads MCP server config.
 
 ## How to use (practical)
-- **Use ChatGPT/Perplexity/Claude normally (manual):** write a plan/spec in the UI, then in Codex call `agentify_read_page` to pull the transcript into your workflow.
-- **Drive ChatGPT/Perplexity/Claude from Codex:** call `agentify_ensure_ready`, then `agentify_query` with a `prompt`. Use a stable `key` per project to keep parallel jobs isolated.
+- **Use ChatGPT/Perplexity/Claude/AI Studio normally (manual):** write a plan/spec in the UI, then in Codex call `agentify_read_page` to pull the transcript into your workflow.
+- **Drive ChatGPT/Perplexity/Claude/AI Studio from Codex:** call `agentify_ensure_ready`, then `agentify_query` with a `prompt`. Use a stable `key` per project to keep parallel jobs isolated.
 - **Parallel jobs:** create/ensure a tab per project with `agentify_tab_create(key: ...)`, then use that `key` for `agentify_query`, `agentify_read_page`, and `agentify_download_images`.
 - **Upload files:** pass local paths via `attachments` to `agentify_query` (best-effort; depends on the site UI).
 - **Generate/download images:** ask for images via `agentify_query` (then call `agentify_download_images`), or use `agentify_image_gen` (prompt + download).

--- a/popup-policy.mjs
+++ b/popup-policy.mjs
@@ -45,7 +45,7 @@ export function isAllowedAuthPopupUrl(url, { vendorId = 'chatgpt' } = {}) {
 
   // Keep behavior conservative: only explicitly allow supported vendor auth flows.
   const vendor = String(vendorId || 'chatgpt').trim().toLowerCase();
-  if (!['chatgpt', 'perplexity', 'claude'].includes(vendor)) return false;
+  if (!['chatgpt', 'perplexity', 'claude', 'aistudio'].includes(vendor)) return false;
 
   return CHATGPT_AUTH_HOST_ALLOWLIST.some((pattern) => hostMatchesPattern(host, pattern));
 }

--- a/selectors.json
+++ b/selectors.json
@@ -1,6 +1,6 @@
 {
   "promptTextarea": "#prompt-textarea, rich-textarea .ql-editor[contenteditable=\"true\"], div.ql-editor[contenteditable=\"true\"], div.ProseMirror[contenteditable=\"true\"], div[contenteditable=\"true\"][aria-label*=\"prompt\" i], div[contenteditable=\"true\"][aria-label*=\"message\" i], textarea[aria-label*=\"prompt\" i], textarea[placeholder*=\"ask\" i], textarea[placeholder*=\"message\" i]",
-  "sendButton": "button[data-testid=\"send-button\"], button[data-testid*=\"send\" i], button[aria-label=\"Send prompt\"], button[aria-label=\"Send\"], button[aria-label*=\"send message\" i], button[aria-label*=\"submit\" i]",
+  "sendButton": "button[data-testid=\"send-button\"], button[data-testid*=\"send\" i], button[aria-label=\"Send prompt\"], button[aria-label=\"Send\"], button[aria-label*=\"send message\" i], button[aria-label*=\"submit\" i], button[aria-label*=\"run\" i], button[title*=\"run\" i]",
   "stopButton": "button[data-testid=\"stop-button\"], button[data-testid*=\"stop\" i], button[aria-label=\"Stop generating\"], button[aria-label=\"Stop\"], button[aria-label*=\"stop response\" i], button[aria-label*=\"cancel\" i]",
   "assistantMessage": "[data-message-author-role=\"assistant\"], model-response, .model-response-text, [data-test-id=\"model-response\"], [data-response-author=\"model\"], article[data-testid*=\"answer\" i], [data-testid*=\"assistant\" i], [data-testid=\"chat-message\"], [data-is-assistant=\"true\"]",
   "composerRoot": "form, main"

--- a/tests/popup-policy.test.mjs
+++ b/tests/popup-policy.test.mjs
@@ -19,6 +19,10 @@ test('popup-policy: allows Google auth popup URL for claude vendor', () => {
   assert.equal(isAllowedAuthPopupUrl('https://accounts.google.com/signin/v2/identifier', { vendorId: 'claude' }), true);
 });
 
+test('popup-policy: allows Google auth popup URL for aistudio vendor', () => {
+  assert.equal(isAllowedAuthPopupUrl('https://accounts.google.com/signin/v2/identifier', { vendorId: 'aistudio' }), true);
+});
+
 test('popup-policy: blocks non-https popup URL', () => {
   assert.equal(isAllowedAuthPopupUrl('http://accounts.google.com/signin/v2/identifier', { vendorId: 'chatgpt' }), false);
 });

--- a/vendors.json
+++ b/vendors.json
@@ -27,8 +27,8 @@
     {
       "id": "aistudio",
       "name": "Google AI Studio",
-      "url": "https://aistudio.google.com/",
-      "status": "planned"
+      "url": "https://aistudio.google.com/prompts/new_chat",
+      "status": "supported"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds Google AI Studio as a supported vendor (new-chat URL) with selector and auth-popup coverage.

## Changes
- Marked AI Studio as supported in `vendors.json`.
- Updated vendor URL to `https://aistudio.google.com/prompts/new_chat`.
- Added AI Studio-friendly send button selector fallbacks (`run` labels).
- Enabled auth popup policy for `aistudio` vendor in `popup-policy.mjs`.
- Added popup-policy test for AI Studio.
- Updated README support matrix and usage wording.

## Validation
- Ran `npm test` in `desktop/`
- Result: 48/48 passing
