### PR TITLE
Fix macOS Control Center missing desktop API + quickstart hardening

### DIFF
--- a/main.mjs
+++ b/main.mjs
@@ -146,7 +146,7 @@ async function main() {
         sandbox: true,
         contextIsolation: true,
         nodeIntegration: false,
-        preload: path.join(__dirname, 'ui', 'preload.mjs')
+        preload: path.join(__dirname, 'ui', 'preload.cjs')
       }
     });
     controlWin.setMenuBarVisibility(false);

--- a/ui/control-center.js
+++ b/ui/control-center.js
@@ -58,7 +58,7 @@ function hasApi(name) {
 async function callApi(name, args, { fallback = null, required = false } = {}) {
   const b = getBridge();
   if (typeof b?.[name] !== 'function') {
-    if (required) throw new Error(`missing_desktop_api:${name} (restart Agentify Desktop)`);
+    if (required) throw new Error(`missing_desktop_api:${name} (open Control Center inside Agentify Desktop, then restart)`);
     return fallback;
   }
   try {

--- a/ui/preload.cjs
+++ b/ui/preload.cjs
@@ -1,0 +1,28 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('agentifyDesktop', {
+  getState: () => ipcRenderer.invoke('agentify:getState'),
+  getSettings: () => ipcRenderer.invoke('agentify:getSettings'),
+  setSettings: (args) => ipcRenderer.invoke('agentify:setSettings', args || {}),
+  getOrchestrators: () => ipcRenderer.invoke('agentify:getOrchestrators'),
+  startOrchestrator: (args) => ipcRenderer.invoke('agentify:startOrchestrator', args || {}),
+  stopOrchestrator: (args) => ipcRenderer.invoke('agentify:stopOrchestrator', args || {}),
+  stopAllOrchestrators: () => ipcRenderer.invoke('agentify:stopAllOrchestrators'),
+  setWorkspaceForKey: (args) => ipcRenderer.invoke('agentify:setWorkspaceForKey', args || {}),
+  getWorkspaceForKey: (args) => ipcRenderer.invoke('agentify:getWorkspaceForKey', args || {}),
+  createTab: (args) => ipcRenderer.invoke('agentify:createTab', args || {}),
+  showTab: (args) => ipcRenderer.invoke('agentify:showTab', args || {}),
+  hideTab: (args) => ipcRenderer.invoke('agentify:hideTab', args || {}),
+  closeTab: (args) => ipcRenderer.invoke('agentify:closeTab', args || {}),
+  openStateDir: () => ipcRenderer.invoke('agentify:openStateDir'),
+  onTabsChanged: (cb) => {
+    if (typeof cb !== 'function') return () => {};
+    const handler = () => cb();
+    ipcRenderer.on('agentify:tabsChanged', handler);
+    return () => {
+      try {
+        ipcRenderer.removeListener('agentify:tabsChanged', handler);
+      } catch {}
+    };
+  }
+});


### PR DESCRIPTION
## Summary
- fix Control Center bridge availability by using a CommonJS preload (`ui/preload.cjs`) and pointing BrowserWindow preload to it
- improve quickstart reliability:
  - fallback to `npm install` when `npm ci` fails due lock drift
  - fail fast when desktop PID/log setup fails instead of reporting false startup
- clarify missing API error hint in Control Center

## Why
Issue #25 reports `missing_desktop_api:createTab` / `missing_desktop_api:getState` and quickstart install/startup friction on macOS.

## Verification
- `npm test` (52/52 passing)
- `bash -n scripts/quickstart.sh`

## Notes
- No auth/token surface changes; only preload bridge bootstrapping and startup script behavior.
