### PR TITLE
Add native Edit menu for paste shortcuts

### DIFF
--- a/main.mjs
+++ b/main.mjs
@@ -268,6 +268,21 @@ async function main() {
         ]
       },
       {
+        label: 'Edit',
+        submenu: [
+          { role: 'undo' },
+          { role: 'redo' },
+          { type: 'separator' },
+          { role: 'cut' },
+          { role: 'copy' },
+          { role: 'paste' },
+          { role: 'pasteAndMatchStyle' },
+          { role: 'delete' },
+          { type: 'separator' },
+          { role: 'selectAll' }
+        ]
+      },
+      {
         label: 'Tabs',
         submenu: [
           {


### PR DESCRIPTION
## Summary
- add a native  menu to the Electron app menu bar
- enable standard cut/copy/paste/select-all shortcuts in embedded input fields

## Testing
- npm test