### PR TITLE
Prepare Agentify Desktop npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Local planning notes are not part of the public package/repo.
+TODO_*.md
+!TODO_fix-sso-popup-hardening.md

--- a/DEVELOPMENT_FROM_SOURCE.md
+++ b/DEVELOPMENT_FROM_SOURCE.md
@@ -1,0 +1,75 @@
+# Development From Source
+
+This guide is for contributors and power users who want to run Agentify Desktop directly from a repo checkout.
+
+For the normal install path, use the npm package from [README.md](/Users/upwiz/crowd4gpt.com/desktop/README.md):
+
+```bash
+npx @agentify/desktop
+```
+
+## Quickstart
+
+Clone the repo and run the helper script:
+
+```bash
+git clone git@github.com:agentify-sh/desktop.git
+cd desktop
+./scripts/quickstart.sh
+```
+
+Useful quickstart variants:
+
+```bash
+./scripts/quickstart.sh --show-tabs
+./scripts/quickstart.sh --foreground
+./scripts/quickstart.sh --client codex
+./scripts/quickstart.sh --client claude
+./scripts/quickstart.sh --client opencode
+./scripts/quickstart.sh --client all
+./scripts/quickstart.sh --client none
+```
+
+## Manual Source Workflow
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the desktop app from source:
+
+```bash
+npm run start
+```
+
+Run the MCP server from source:
+
+```bash
+npm run mcp
+```
+
+Run tests:
+
+```bash
+npm test
+```
+
+Build distributable desktop artifacts:
+
+```bash
+npm run dist
+```
+
+Smoke-test the npm launcher from source:
+
+```bash
+node ./bin/agentify-desktop.mjs --help
+```
+
+## When Source Mode Helps
+
+- You are modifying Electron or MCP server code.
+- You want to debug startup or login issues with local logs.
+- You need to test changes before publishing a new npm package.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,21 @@ Agentify Desktop is a local control center for AI web sessions. It lets MCP-capa
 - Packs local repo/file context into prompts when requested.
 - Saves generated images/files locally so they can be reused in follow-up prompts.
 
-## Install And Run
+## Requirements
+
+- Node.js 20 or newer
+- An MCP-capable CLI if you want tool integration: Codex, Claude Code, or OpenCode
+
+## Supported Sites
+
+- `chatgpt.com`
+- `claude.ai`
+- `perplexity.ai`
+- `aistudio.google.com`
+- `gemini.google.com`
+- `grok.com`
+
+## Preferred Install And Run
 
 Start the desktop GUI without cloning this repo:
 
@@ -31,6 +45,8 @@ If you prefer a global install:
 npm install -g @agentify/desktop
 agentify-desktop
 ```
+
+If you want the older repo-clone and local source workflow, use [DEVELOPMENT_FROM_SOURCE.md](/Users/upwiz/crowd4gpt.com/desktop/DEVELOPMENT_FROM_SOURCE.md).
 
 ## MCP Server
 
@@ -267,61 +283,7 @@ Anyone with access to your machine account may be able to access local session d
 
 ## Development From Source
 
-If you want the repo checkout workflow instead of the published npm package:
-
-```bash
-git clone git@github.com:agentify-sh/desktop.git
-cd desktop
-./scripts/quickstart.sh
-```
-
-Useful quickstart variants:
-
-```bash
-./scripts/quickstart.sh --show-tabs
-./scripts/quickstart.sh --foreground
-./scripts/quickstart.sh --client codex
-./scripts/quickstart.sh --client claude
-./scripts/quickstart.sh --client opencode
-./scripts/quickstart.sh --client all
-./scripts/quickstart.sh --client none
-```
-
-Install dependencies:
-
-```bash
-npm install
-```
-
-Run the desktop app from source:
-
-```bash
-npm run start
-```
-
-Run the MCP server from source:
-
-```bash
-npm run mcp
-```
-
-Run tests:
-
-```bash
-npm test
-```
-
-Build distributable app artifacts:
-
-```bash
-npm run dist
-```
-
-Test the npm launcher locally:
-
-```bash
-node ./bin/agentify-desktop.mjs --help
-```
+Source checkout, quickstart script usage, local build commands, and source-only debugging notes live in [DEVELOPMENT_FROM_SOURCE.md](/Users/upwiz/crowd4gpt.com/desktop/DEVELOPMENT_FROM_SOURCE.md).
 
 ## Package Commands
 
@@ -338,3 +300,7 @@ npx @agentify/desktop
 npx @agentify/desktop mcp
 npx -p @agentify/desktop agentify-desktop-mcp
 ```
+
+## License And Trademarks
+
+The code is licensed under `MPL-2.0`. Agentify trademarks and branding are not included in that license. See [TRADEMARKS.md](/Users/upwiz/crowd4gpt.com/desktop/TRADEMARKS.md).

--- a/README.md
+++ b/README.md
@@ -265,7 +265,27 @@ Anyone with access to your machine account may be able to access local session d
 - `AGENTIFY_DESKTOP_CHROME_PROFILE_MODE=isolated|existing`: choose Chrome profile mode.
 - `AGENTIFY_DESKTOP_CHROME_PROFILE_NAME`: choose an existing Chrome profile name.
 
-## Development
+## Development From Source
+
+If you want the repo checkout workflow instead of the published npm package:
+
+```bash
+git clone git@github.com:agentify-sh/desktop.git
+cd desktop
+./scripts/quickstart.sh
+```
+
+Useful quickstart variants:
+
+```bash
+./scripts/quickstart.sh --show-tabs
+./scripts/quickstart.sh --foreground
+./scripts/quickstart.sh --client codex
+./scripts/quickstart.sh --client claude
+./scripts/quickstart.sh --client opencode
+./scripts/quickstart.sh --client all
+./scripts/quickstart.sh --client none
+```
 
 Install dependencies:
 

--- a/README.md
+++ b/README.md
@@ -1,162 +1,150 @@
 # Agentify Desktop
 
-Agentify Desktop is a local-first control center for AI work: connect your real, logged-in AI subscriptions to your MCP-compatible CLI tools, all on your own machine.
+Agentify Desktop is a local control center for AI web sessions. It lets MCP-capable tools such as Codex, Claude Code, and OpenCode use the AI subscriptions you are already signed into, while keeping browser state, files, and automation on your machine.
 
-### Why teams keep it open
-- `🌐` **Real browser sessions, real accounts**: automate the web UIs you already use, without API-key migration.
-- `🔌` **MCP-native integration**: works with Codex, Claude Code, OpenCode, and other MCP-capable clients.
-- `🧵` **Parallel tabs for parallel work**: run multiple isolated workflows at once using stable tab keys.
-- `📎` **Practical I/O support**: upload files, save generated images/files locally, and reattach them in later prompts.
+## What It Does
 
-## Supported sites
-**Supported**
-- `chatgpt.com`
-- `perplexity.ai`
-- `claude.ai`
-- `aistudio.google.com`
-- `gemini.google.com`
-- `grok.com`
+- Opens a local Agentify Control Center.
+- Manages signed-in browser sessions for ChatGPT, Claude, Perplexity, Gemini, Google AI Studio, and Grok.
+- Exposes MCP tools for querying a tab, reading a page, navigating, uploading files, saving artifacts, and reusing stable tab keys.
+- Supports parallel tabs so different agents or tasks can use separate sessions.
+- Packs local repo/file context into prompts when requested.
+- Saves generated images/files locally so they can be reused in follow-up prompts.
 
-**Planned**
-- Additional vendor profiles via `vendors.json` + selector overrides.
+## Install And Run
 
-## CAPTCHA policy (human-in-the-loop)
-Agentify Desktop does **not** attempt to bypass CAPTCHAs or use third-party solvers. If a human verification appears, the app pauses automation, brings the relevant window to the front, and waits for you to complete the check manually.
-
-## Requirements
-- Node.js 20+ (22 recommended)
-- MCP-capable CLI (optional, for MCP): Codex, Claude Code, or OpenCode
-
-## Quickstart (macOS/Linux)
-Quickstart installs dependencies, auto-registers the MCP server for installed clients (Codex/Claude Code/OpenCode), and starts Agentify Desktop:
+Start the desktop GUI without cloning this repo:
 
 ```bash
-git clone git@github.com:agentify-sh/desktop.git
-cd desktop
-./scripts/quickstart.sh
+npx @agentify/desktop
 ```
 
-Debug-friendly: show newly-created tab windows by default:
+Equivalent explicit GUI command:
+
 ```bash
-./scripts/quickstart.sh --show-tabs
+npx @agentify/desktop gui
 ```
 
-Foreground mode (logs to your terminal, Ctrl+C to stop):
+If you prefer a global install:
+
 ```bash
-./scripts/quickstart.sh --foreground
+npm install -g @agentify/desktop
+agentify-desktop
 ```
 
-Choose MCP registration target explicitly:
+## MCP Server
+
+Run the MCP server over stdio:
+
 ```bash
-./scripts/quickstart.sh --client auto     # default
-./scripts/quickstart.sh --client codex
-./scripts/quickstart.sh --client claude
-./scripts/quickstart.sh --client opencode
-./scripts/quickstart.sh --client all
-./scripts/quickstart.sh --client none
+npx @agentify/desktop mcp
 ```
 
-## Manual install & run
+Show newly-created browser tabs while debugging:
+
 ```bash
-npm i
-npm run start
+npx @agentify/desktop mcp --show-tabs
 ```
 
-The Agentify Control Center opens. Use it to:
-- Show/hide tabs (each tab is a separate window)
-- Create tabs for ChatGPT, Perplexity, Claude, Google AI Studio, Gemini, and Grok
-- Tune automation safety limits (governor)
+With a global install:
 
-Sign in to your target vendor in the tab window.
-
-If your account uses SSO (Google/Microsoft/Apple), keep **Settings → Allow auth popups** enabled in the Control Center. ChatGPT login often opens provider auth in a popup, and blocking popups can prevent login from completing.
-
-## Browser backend choice
-Agentify Desktop now supports two browser backends:
-
-- `electron` (default): embedded windows managed directly by Agentify.
-- `chrome-cdp`: launches/attaches a real Chrome-family browser via the Chrome DevTools Protocol.
-
-If Google/Microsoft/Apple SSO is fighting Electron, switch to **Settings → Browser backend → Chrome CDP**, save, then restart Agentify Desktop.
-
-`chrome-cdp` notes:
-- Uses a managed browser profile at `~/.agentify-desktop/chrome-user-data/`
-- Default remote debugging port is `9222`
-- Prefers your local Chrome install, but also works with Chromium / Brave / Edge
-- Uses real browser login flows, which is the main reason to choose it
-
-Profile options in the Control Center:
-- `Agentify isolated profile` (default): safest and most predictable
-- `Existing Chrome profile`: reuses your normal Chrome session/profile
-
-If you choose `Existing Chrome profile`, fully quit regular Chrome first, then start Agentify Desktop. If Chrome is already using that profile, Agentify will fail fast with a hint instead of attaching to the wrong browser state.
-
-## First Useful Workflow
-This is the simplest real workflow to prove the product is doing something useful.
-
-1. Start Agentify Desktop:
 ```bash
-npm i
-npm run start
+agentify-desktop-mcp
+agentify-desktop-mcp --show-tabs
 ```
 
-2. In the Control Center:
-- set `Browser backend` to `Chrome CDP`
-- keep `Chrome profile mode` as `Agentify isolated profile`
-- click `Save`
-- restart Agentify Desktop if you changed the backend
-
-3. Click `Show default`, then sign in to ChatGPT in the browser window.
-
-4. Register the MCP server in your CLI.
+## Register With MCP Clients
 
 Codex:
+
 ```bash
-codex mcp add agentify-desktop -- node /ABS/PATH/TO/desktop/mcp-server.mjs
+codex mcp add agentify-desktop -- npx -y @agentify/desktop mcp
 ```
 
 Claude Code:
+
 ```bash
-claude mcp add --transport stdio agentify-desktop -- node /ABS/PATH/TO/desktop/mcp-server.mjs
+claude mcp add --transport stdio agentify-desktop -- npx -y @agentify/desktop mcp
 ```
 
-5. In your MCP client, run this exact workflow:
+OpenCode config example:
 
-Prompt:
+```json
+{
+  "mcp": {
+    "agentify-desktop": {
+      "type": "local",
+      "command": ["npx", "-y", "@agentify/desktop", "mcp"],
+      "enabled": true
+    }
+  }
+}
+```
+
+Use `--show-tabs` at the end of the command while debugging:
+
+```bash
+codex mcp add agentify-desktop -- npx -y @agentify/desktop mcp --show-tabs
+```
+
+## First Run
+
+1. Start the app:
+
+```bash
+npx @agentify/desktop
+```
+
+2. In the Control Center, create or show a ChatGPT tab.
+
+3. Sign in to the target vendor in the browser window.
+
+4. Register the MCP server with your CLI.
+
+5. Ask your MCP client to use Agentify:
+
 ```text
-Create or reuse an Agentify tab with key repo-triage.
-Use ChatGPT to answer this:
-"Summarize the architecture of this repo in 8 bullets, then list the top 3 risky areas to change first."
+Use Agentify Desktop with tab key repo-triage.
+Ask ChatGPT to summarize this repo in 8 bullets and list the top 3 risky areas to change first.
 Return the answer and keep the tab key stable for follow-ups.
 ```
 
-6. Follow up in the same tab:
+The core loop is:
 
-Prompt:
-```text
-Use the existing Agentify tab key repo-triage.
-Ask for a test plan for changing one of those risky areas.
-Return the plan as a short checklist.
+- keep a real signed-in browser session open locally
+- call it from an MCP client
+- reuse a stable tab key across follow-up prompts
+
+## Useful MCP Tools
+
+The MCP server registers `agentify_*` tools, including:
+
+- `agentify_query`: send a prompt to a stable tab and return the assistant response.
+- `agentify_read_page`: read visible page text from a tab.
+- `agentify_navigate`: navigate a tab to a URL.
+- `agentify_ensure_ready`: wait for login, CAPTCHA, or UI readiness.
+- `agentify_show` / `agentify_hide`: bring windows forward or minimize them.
+- `agentify_status`: inspect tab and readiness state.
+- `agentify_tabs`, `agentify_tab_create`, `agentify_tab_close`: manage tabs.
+- `agentify_save_artifacts`, `agentify_list_artifacts`, `agentify_open_artifacts_folder`: manage generated files/images.
+- `agentify_save_bundle`, `agentify_list_bundles`: save and reuse context bundles.
+- `agentify_add_watch_folder`, `agentify_list_watch_folders`, `agentify_remove_watch_folder`: manage watched folders.
+
+## Artifact Workflow
+
+Generate an image or file in a stable tab:
+
+```json
+{
+  "tool": "agentify_query",
+  "arguments": {
+    "key": "sprite-lab",
+    "prompt": "Generate 3 simple 2D pixel-art robot sprite variations on transparent backgrounds."
+  }
+}
 ```
 
-That proves the core loop:
-- keep a persistent logged-in web session
-- call it from Codex / Claude Code over MCP
-- reuse the same tab/session across multiple requests
-
-### First artifact workflow
-This is the fastest way to prove the image/file pipeline is useful.
-
-1. Generate something in a stable tab:
-
-Prompt:
-```text
-Use tab key sprite-lab.
-Generate a simple 2D pixel-art robot sprite on a transparent background.
-Give me 3 variations.
-```
-
-2. Save the latest generated outputs to disk:
+Save the generated images locally:
 
 ```json
 {
@@ -169,43 +157,22 @@ Give me 3 variations.
 }
 ```
 
-The response includes local file paths. You can immediately reuse one of them in the next step.
-
-3. Reattach one of the returned paths in the next prompt:
+Reattach one of the returned file paths in a follow-up:
 
 ```json
 {
   "tool": "agentify_query",
   "arguments": {
     "key": "sprite-lab",
-    "prompt": "Take the attached sprite and create a damaged version with one broken eye and darker metal.",
-    "attachments": [
-      "/ABS/PATH/FROM/PREVIOUS/STEP/sprite.png"
-    ]
+    "prompt": "Use the attached sprite and make a damaged version with one broken eye.",
+    "attachments": ["/absolute/path/to/sprite.png"]
   }
 }
 ```
 
-4. If you want the folder in Finder/Explorer:
+## Codebase Context Workflow
 
-```json
-{
-  "tool": "agentify_open_artifacts_folder",
-  "arguments": {
-    "key": "sprite-lab"
-  }
-}
-```
-
-That proves the artifact loop:
-- generate in a real web session
-- save locally without manual browser downloads
-- reuse the saved file path in the next MCP prompt
-
-### First codebase stuffing workflow
-Use this when you want to hand a repo or folder tree to the model without manually copy/pasting files.
-
-1. Ask Agentify to pack a folder into the next query:
+Ask Agentify to pack local files or folders into a prompt:
 
 ```json
 {
@@ -213,356 +180,141 @@ Use this when you want to hand a repo or folder tree to the model without manual
   "arguments": {
     "key": "repo-review",
     "prompt": "Summarize this codebase in 8 bullets and list the top 3 risky files to change first.",
-    "contextPaths": [
-      "/ABS/PATH/TO/YOUR/REPO"
-    ]
+    "contextPaths": ["/absolute/path/to/repo"]
   }
 }
 ```
 
-2. Inspect the returned `packedContextSummary` in the tool result.
-
-It tells you, at a glance:
-- which roots were scanned
-- how many files were scanned
-- which text files were inlined
-- which files were auto-attached
-- which files were skipped and why
-
-3. If the first pass is too large or too small, tighten the budget explicitly:
+Control context size:
 
 ```json
 {
   "tool": "agentify_query",
   "arguments": {
     "key": "repo-review",
-    "prompt": "Focus only on the rendering pipeline and state management.",
-    "contextPaths": [
-      "/ABS/PATH/TO/YOUR/REPO"
-    ],
-    "maxContextChars": 60000,
-    "maxContextFiles": 40,
-    "maxContextChunkChars": 4000,
-    "maxContextChunksPerFile": 2,
-    "maxContextInlineFiles": 12,
-    "maxContextAttachments": 6
+    "prompt": "Focus only on rendering and state management.",
+    "contextPaths": ["/absolute/path/to/repo"],
+    "maxContextChars": 120000,
+    "maxContextFiles": 80,
+    "maxContextInlineFiles": 30
   }
 }
 ```
 
-4. Reuse the same tab key for follow-ups:
+The tool result includes `packedContextSummary` so you can see what was included, attached, or skipped.
 
-```json
-{
-  "tool": "agentify_query",
-  "arguments": {
-    "key": "repo-review",
-    "prompt": "Now give me a safe refactor plan for the top risky file."
-  }
-}
-```
+## Browser Backend
 
-That proves the codebase loop:
-- point Agentify at a folder
-- let it inline text files and auto-attach binaries/images
-- inspect what it included vs skipped
-- keep the same live session for follow-up questions
+Agentify Desktop supports two browser backends:
 
-### Watch-folder ingestion workflow
-Use this when you want a dead-simple local drop zone.
+- `electron`: embedded windows managed by Agentify Desktop. This is the default.
+- `chrome-cdp`: launches or attaches to a Chrome-family browser over Chrome DevTools Protocol.
 
-1. Open the default inbox folder:
+Use Chrome CDP when SSO providers fight embedded Electron login:
 
-```json
-{
-  "tool": "agentify_open_watch_folder",
-  "arguments": {}
-}
-```
-
-2. Drop files into that folder from Finder/Explorer or another local tool.
-
-3. Agentify will index them automatically. If you want to force it immediately:
-
-```json
-{
-  "tool": "agentify_scan_watch_folder",
-  "arguments": {}
-}
-```
-
-4. List the ingested files and reuse their paths:
-
-```json
-{
-  "tool": "agentify_list_artifacts",
-  "arguments": {
-    "limit": 20
-  }
-}
-```
-
-Then pass one of the returned `path` values into the next `attachments` array.
-
-You can also add your own watched folders:
-
-```json
-{
-  "tool": "agentify_add_watch_folder",
-  "arguments": {
-    "name": "sprites",
-    "folderPath": "/ABS/PATH/TO/sprites"
-  }
-}
-```
-
-List them:
-
-```json
-{
-  "tool": "agentify_list_watch_folders",
-  "arguments": {}
-}
-```
-
-Remove one later:
-
-```json
-{
-  "tool": "agentify_remove_watch_folder",
-  "arguments": {
-    "name": "sprites"
-  }
-}
-```
-
-### Reusable context bundle workflow
-Use this when you keep sending the same codebase roots, screenshots, and instruction prefix.
-
-1. Save a bundle once:
-
-```json
-{
-  "tool": "agentify_save_bundle",
-  "arguments": {
-    "name": "repo-review",
-    "promptPrefix": "You are reviewing this repository for safe incremental changes. Be concrete and concise.",
-    "contextPaths": [
-      "/ABS/PATH/TO/repo/src",
-      "/ABS/PATH/TO/repo/package.json"
-    ],
-    "attachments": [
-      "/ABS/PATH/TO/repo/docs/architecture.png"
-    ]
-  }
-}
-```
-
-2. Reuse it later in a normal query:
-
-```json
-{
-  "tool": "agentify_query",
-  "arguments": {
-    "key": "repo-review-chatgpt",
-    "bundleName": "repo-review",
-    "prompt": "Find the riskiest auth-related change points and propose the smallest safe refactor plan."
-  }
-}
-```
-
-3. If needed, add extra one-off context on top of the bundle:
-
-```json
-{
-  "tool": "agentify_query",
-  "arguments": {
-    "key": "repo-review-chatgpt",
-    "bundleName": "repo-review",
-    "promptPrefix": "Prioritize fixes we can ship today.",
-    "contextPaths": [
-      "/ABS/PATH/TO/repo/new-module"
-    ],
-    "prompt": "Update the plan with the new module included."
-  }
-}
-```
-
-Good next workflow:
-- create separate keys like `cmp-chatgpt`, `cmp-claude`, `cmp-gemini`
-- send the same architecture prompt to each
-- compare answers before making changes
-
-Optional overrides:
 ```bash
-AGENTIFY_DESKTOP_BROWSER_BACKEND=chrome-cdp npm run start
-AGENTIFY_DESKTOP_CHROME_DEBUG_PORT=9333 npm run start
-AGENTIFY_DESKTOP_CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" npm run start
+AGENTIFY_DESKTOP_BROWSER_BACKEND=chrome-cdp npx @agentify/desktop
 ```
 
-Equivalent CLI flags:
+Optional Chrome CDP settings:
+
 ```bash
-npm run start -- --browser-backend chrome-cdp
-npm run start -- --chrome-debug-port 9333
-npm run start -- --chrome-binary "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+AGENTIFY_DESKTOP_CHROME_DEBUG_PORT=9333 npx @agentify/desktop
+AGENTIFY_DESKTOP_CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" npx @agentify/desktop
 ```
 
-## Connect from MCP clients
-Quickstart can register MCP automatically, but manual commands are below if you prefer explicit setup.
+You can also pass GUI flags:
 
-### Codex
-From the repo root:
 ```bash
-codex mcp add agentify-desktop -- node mcp-server.mjs [--show-tabs]
+npx @agentify/desktop gui --browser-backend chrome-cdp
+npx @agentify/desktop gui --chrome-debug-port 9333
 ```
 
-From anywhere (absolute path):
+Chrome CDP profile modes:
+
+- `Agentify isolated profile`: safest default.
+- `Existing Chrome profile`: reuses your normal Chrome session. Fully quit Chrome first so the profile is not already locked.
+
+## CAPTCHA And Login Policy
+
+Agentify Desktop does not bypass CAPTCHAs or use third-party solvers. If a verification or login challenge appears, automation pauses, brings the relevant window forward, and waits for you to complete the step manually.
+
+If your account uses Google, Microsoft, or Apple SSO, keep auth popups enabled in the Control Center. If embedded login remains unreliable, use Chrome CDP.
+
+## Local Data And Privacy
+
+Agentify Desktop is local-first:
+
+- The local API binds to `127.0.0.1`.
+- The local API requires a bearer token stored under `~/.agentify-desktop/`.
+- Electron browser data is stored under `~/.agentify-desktop/electron-user-data/`.
+- Chrome CDP profile data is stored under `~/.agentify-desktop/chrome-user-data/` unless you choose an existing profile.
+- Artifacts, bundles, logs, and state are stored under `~/.agentify-desktop/`.
+
+Anyone with access to your machine account may be able to access local session data. Treat the machine account as the security boundary.
+
+## Environment Variables
+
+- `AGENTIFY_DESKTOP_STATE_DIR`: override the local state directory.
+- `AGENTIFY_DESKTOP_PORT`: choose the local API port.
+- `AGENTIFY_DESKTOP_SHOW_TABS=true`: show newly-created tabs by default.
+- `AGENTIFY_DESKTOP_MAX_TABS`: cap parallel tabs.
+- `AGENTIFY_DESKTOP_BROWSER_BACKEND=electron|chrome-cdp`: choose browser backend.
+- `AGENTIFY_DESKTOP_CHROME_BIN`: choose Chrome/Chromium executable.
+- `AGENTIFY_DESKTOP_CHROME_DEBUG_PORT`: choose Chrome debug port.
+- `AGENTIFY_DESKTOP_CHROME_PROFILE_MODE=isolated|existing`: choose Chrome profile mode.
+- `AGENTIFY_DESKTOP_CHROME_PROFILE_NAME`: choose an existing Chrome profile name.
+
+## Development
+
+Install dependencies:
+
 ```bash
-codex mcp add agentify-desktop -- node /ABS/PATH/TO/desktop/mcp-server.mjs [--show-tabs]
+npm install
 ```
 
-Confirm registration:
+Run the desktop app from source:
+
 ```bash
-codex mcp list
+npm run start
 ```
 
-### Claude Code
-From the repo root:
+Run the MCP server from source:
+
 ```bash
-claude mcp add --transport stdio agentify-desktop -- node mcp-server.mjs [--show-tabs]
+npm run mcp
 ```
 
-From anywhere (absolute path):
+Run tests:
+
 ```bash
-claude mcp add --transport stdio agentify-desktop -- node /ABS/PATH/TO/desktop/mcp-server.mjs [--show-tabs]
+npm test
 ```
 
-Confirm registration:
-```bash
-claude mcp list
-```
+Build distributable app artifacts:
 
-### OpenCode
-OpenCode can be configured in `~/.config/opencode/opencode.json`:
-```json
-{
-  "mcp": {
-    "agentify-desktop": {
-      "type": "local",
-      "command": ["node", "/ABS/PATH/TO/desktop/mcp-server.mjs"],
-      "enabled": true
-    }
-  }
-}
-```
-
-`./scripts/quickstart.sh --client opencode` (or `--client all`) writes/updates this entry automatically.
-
-Confirm registration:
-```bash
-opencode mcp list
-```
-
-If you already had your client open, restart it (or start a new session) so it reloads MCP server config.
-
-## Developer workflows (natural language)
-Use plain requests in your MCP client. You usually do not need to call tool IDs directly.
-
-1. **Plan in ChatGPT Pro or Gemini Deep Think, then execute in phases.**
-Prompt:
-"Open a Gemini tab with key `plan-auth-v2`, ask Deep Think for a migration plan from session cookies to JWT in this repo, and return a 10-step checklist with risk and rollback per step."
-Follow-up:
-"Now use key `plan-auth-v2` and generate step 1 implementation only, including tests."
-
-2. **Prompt all vendors and compare output quality before coding.**
-Prompt:
-"Create tabs for keys `cmp-chatgpt`, `cmp-claude`, `cmp-gemini`, and `cmp-perplexity`. Send the same architecture prompt to each. Then compare responses in a table by correctness, operational risk, implementation complexity, and testability."
-
-3. **Run incident triage with attached evidence.**
-Prompt:
-"Open key `incident-prod-api`, send `./incident/error.log` and `./incident/dashboard.png`, and produce: likely root cause, 30-minute hotfix plan, rollback, and validation checklist."
-
-Use explicit tool calls (`agentify_query`, `agentify_read_page`, etc.) when you need deterministic/reproducible runs or when debugging tool selection.
-
-## How to use (practical)
-- **Use ChatGPT/Perplexity/Claude/AI Studio/Gemini/Grok normally (manual):** write a plan/spec in the UI, then in your MCP client call `agentify_read_page` to pull the transcript into your workflow.
-- **Drive ChatGPT/Perplexity/Claude/AI Studio/Gemini/Grok from your MCP client:** call `agentify_ensure_ready`, then `agentify_query` with a `prompt`. Use a stable `key` per project to keep parallel jobs isolated.
-- **Parallel jobs:** create/ensure a tab per project with `agentify_tab_create(key: ...)`, then use that `key` for `agentify_query`, `agentify_read_page`, and `agentify_download_images`.
-- **Upload files:** pass local paths via `attachments` to `agentify_query` (best-effort; depends on the site UI).
-- **Generate/save/reuse artifacts:** ask for images/files via `agentify_query`, then call `agentify_save_artifacts` or `agentify_download_images`. Reuse the returned local paths in the next `attachments` array.
-- **Open the artifact folder quickly:** call `agentify_open_artifacts_folder` or click `Artifacts` in the Control Center.
-- **Use local inbox/watch folders:** call `agentify_open_watch_folder`, `agentify_add_watch_folder`, or manage them in the Control Center. Each watched folder has a one-click open button in the UI.
-- **Stuff folder context into a prompt:** pass `contextPaths` to `agentify_query`. Agentify will inline chunked text files into the prompt and auto-attach small binary/image files when useful.
-- **Tune large-context packing when needed:** `agentify_query` also accepts `maxContextChars`, `maxContextFiles`, `maxContextFileChars`, `maxContextChunkChars`, `maxContextChunksPerFile`, `maxContextInlineFiles`, and `maxContextAttachments`.
-- **Vendor-aware context budgets:** packed context defaults are tuned by the target vendor/tab so large folder stuffing is less aggressive on narrower UIs and more generous where it makes sense.
-- **Break-glass stop for stuck runs:** `agentify_status` includes `activeQuery` / `runtime.activeQueries`, `agentify_stop_query` requests a stop, and the Control Center shows a `Stop` button on tabs with a running job.
-- **Reuse project context without rebuilding it every time:** save a named bundle with `agentify_save_bundle`, then pass `bundleName` to `agentify_query`.
-
-## Real-world prompt example
-Example `agentify_query` input:
-```json
-{
-  "key": "incident-triage-prod-api",
-  "promptPrefix": "Prefer precise shell commands and call out risky assumptions.",
-  "prompt": "You are my senior incident engineer. I attached a production error log and a screenshot from our monitoring dashboard.\\n\\nGoal: produce a high-confidence triage summary and a safe hotfix plan I can execute in 30 minutes.\\n\\nRequirements:\\n1) Identify the most likely root cause with evidence from the log lines.\\n2) List top 3 hypotheses and how to falsify each quickly.\\n3) Give a step-by-step hotfix plan with exact commands.\\n4) Include rollback steps and post-fix validation checks.\\n5) Keep response concise and actionable.\\n\\nReturn format:\\n- Root cause\\n- Evidence\\n- 30-minute hotfix plan\\n- Rollback\\n- Validation checklist",
-  "attachments": [
-    "./incident/error.log",
-    "./incident/dashboard.png"
-  ],
-  "contextPaths": [
-    "./src",
-    "./package.json"
-  ],
-  "timeoutMs": 600000
-}
-```
-
-## What's new
-- First-class multi-vendor tab support now includes Perplexity, Claude, Google AI Studio, Gemini, and Grok.
-- Control Center reliability and UX were hardened (state/refresh wiring, tab actions, compact controls, clearer field guidance).
-- Local API hardening includes strict invalid JSON handling, key/vendor mismatch protection, and safer tab-key recovery.
-- Desktop runtime hardening includes Control Center sandboxing plus dependency security updates.
-
-## Governor (anti-spam)
-Agentify Desktop includes a built-in governor to reduce accidental high-rate automation:
-- Limits concurrent in-flight queries
-- Limits queries per minute (token bucket)
-- Enforces minimum gaps between queries (per tab + globally)
-
-You can adjust these limits in the Control Center after acknowledging the disclaimer.
-
-## Not Supported Right Now
-The experimental orchestrator / single-chat emulator is intentionally hidden from the desktop UI and is not supported right now.
-The supported product surface is the local browser-control + MCP workflow described above.
-
-## Limitations / robustness notes
-- **File upload selectors:** `input[type=file]` selection is best-effort; if ChatGPT changes the upload flow, update `selectors.json` or `~/.agentify-desktop/selectors.override.json`.
-- **Perplexity selectors:** Perplexity support is best-effort and may require selector overrides in `~/.agentify-desktop/selectors.override.json` if UI changes.
-- **Gemini selectors:** Gemini support is best-effort and may require selector overrides in `~/.agentify-desktop/selectors.override.json` if UI changes.
-- **Completion detection:** waiting for “stop generating” to disappear + text stability works well, but can mis-detect on very long outputs or intermittent streaming pauses.
-- **Image downloads:** prefers `<img>` elements in the latest assistant message; some UI modes may render images via nonstandard elements.
-- **Parallelism model:** “tabs” are separate windows; they can run in parallel without stealing focus unless a human check is required.
-- **Security knobs:** default is loopback-only + bearer token; token rotation and shutdown are supported via MCP tools.
-
-## Login troubleshooting (Google SSO)
-- Symptom: login shows “This browser or app may not be secure” or the flow never completes.
-- Check 1: In Control Center, enable `Allow auth popups (needed for Google/Microsoft/Apple SSO)`.
-- Check 2: Retry login from a fresh ChatGPT tab (`Create tab` → `ChatGPT` → `Show`).
-- Check 3: If your provider asks for WebAuthn/security key prompts, complete/cancel once and continue; some providers require that step before password/passkey fallback.
-- Check 4: Switch to the `chrome-cdp` backend and restart. This uses a real Chrome-family browser and avoids the embedded Electron auth path entirely.
-
-## Build installers (unsigned)
 ```bash
 npm run dist
 ```
-Artifacts land in `dist/`.
 
-## Security and data
-- Control API binds to `127.0.0.1` on an ephemeral port by default.
-- Auth uses a local bearer token stored under `~/.agentify-desktop/`.
-- Electron session data (cookies/local storage) is stored under `~/.agentify-desktop/electron-user-data/`.
+Test the npm launcher locally:
 
-See `SECURITY.md`.
+```bash
+node ./bin/agentify-desktop.mjs --help
+```
 
-## Trademarks
-Forks/derivatives may not use Agentify branding. See `TRADEMARKS.md`.
+## Package Commands
+
+The npm package exposes these commands:
+
+- `agentify-desktop`: default GUI launcher, with `mcp` subcommand support.
+- `agentify-desktop-gui`: explicit GUI alias.
+- `agentify-desktop-mcp`: explicit MCP alias.
+
+Examples:
+
+```bash
+npx @agentify/desktop
+npx @agentify/desktop mcp
+npx -p @agentify/desktop agentify-desktop-mcp
+```

--- a/bin/agentify-desktop.mjs
+++ b/bin/agentify-desktop.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, '..');
+
+function printHelp() {
+  console.log(`Agentify Desktop
+
+Usage:
+  agentify-desktop [gui] [options]
+  agentify-desktop mcp [options]
+
+Commands:
+  gui    Start the Agentify Desktop control center. This is the default.
+  mcp    Run the Agentify Desktop MCP server over stdio.
+
+Examples:
+  npx @agentify/desktop
+  npx @agentify/desktop mcp
+  npx @agentify/desktop mcp --show-tabs
+
+GUI options are passed to the Electron app.
+MCP options are passed to mcp-server.mjs.`);
+}
+
+function resolveMode(invokedName, argv) {
+  if (invokedName.endsWith('-mcp')) return { mode: 'mcp', args: argv };
+  if (invokedName.endsWith('-gui')) return { mode: 'gui', args: argv };
+
+  const [first, ...rest] = argv;
+  if (!first || first.startsWith('-')) return { mode: 'gui', args: argv };
+  if (first === 'gui' || first === 'start') return { mode: 'gui', args: rest };
+  if (first === 'mcp') return { mode: 'mcp', args: rest };
+  if (first === 'help') return { mode: 'help', args: rest };
+  return { mode: 'unknown', args: argv };
+}
+
+function electronBin() {
+  const local = path.join(
+    packageRoot,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'electron.cmd' : 'electron'
+  );
+  if (fs.existsSync(local)) return local;
+  return process.env.AGENTIFY_DESKTOP_ELECTRON_BIN || 'electron';
+}
+
+async function runMcp(args) {
+  const serverPath = path.join(packageRoot, 'mcp-server.mjs');
+  process.argv = [process.argv[0], serverPath, ...args];
+  await import(pathToFileURL(serverPath).href);
+}
+
+function runGui(args) {
+  const child = spawn(electronBin(), [packageRoot, ...args], {
+    stdio: 'inherit',
+    env: process.env
+  });
+  child.on('error', (err) => {
+    console.error(`agentify-desktop failed to start: ${err.message}`);
+    process.exit(1);
+  });
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      console.error(`agentify-desktop exited from signal ${signal}`);
+      process.exit(1);
+    }
+    process.exit(code ?? 0);
+  });
+}
+
+const invokedName = path.basename(process.argv[1] || 'agentify-desktop');
+const argv = process.argv.slice(2);
+if (argv.includes('--help') || argv.includes('-h')) {
+  printHelp();
+  process.exit(0);
+}
+
+const { mode, args } = resolveMode(invokedName, argv);
+if (mode === 'help') {
+  printHelp();
+} else if (mode === 'mcp') {
+  await runMcp(args);
+} else if (mode === 'gui') {
+  runGui(args);
+} else {
+  console.error(`Unknown Agentify Desktop command: ${args[0] || argv[0]}`);
+  console.error('Run `agentify-desktop --help` for usage.');
+  process.exit(2);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@agentify/desktop",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "MPL-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "electron": "^39.8.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentify/desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentify/desktop",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,25 @@
 {
-  "name": "agentify-desktop",
+  "name": "@agentify/desktop",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agentify-desktop",
+      "name": "@agentify/desktop",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0",
-        "electron": "^39.6.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "electron": "^39.8.7",
         "zod": "^3.22.3"
       },
+      "bin": {
+        "agentify-desktop": "bin/agentify-desktop.mjs",
+        "agentify-desktop-gui": "bin/agentify-desktop.mjs",
+        "agentify-desktop-mcp": "bin/agentify-desktop.mjs"
+      },
       "devDependencies": {
-        "electron-builder": "^26.7.0"
+        "electron-builder": "^26.8.1"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -33,40 +39,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/@develar/schema-utils/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@develar/schema-utils/node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/@develar/schema-utils/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
@@ -94,9 +66,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -105,9 +77,9 @@
       }
     },
     "node_modules/@electron/asar/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -387,9 +359,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -397,9 +369,9 @@
       }
     },
     "node_modules/@electron/universal/node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -425,13 +397,13 @@
       }
     },
     "node_modules/@electron/universal/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -450,10 +422,76 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@electron/windows-sign": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "cross-dirname": "^0.1.0",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.1.1",
+        "minimist": "^1.2.8",
+        "postject": "^1.0.0-alpha.6"
+      },
+      "bin": {
+        "electron-windows-sign": "bin/electron-windows-sign.js"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -463,13 +501,106 @@
       }
     },
     "node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -564,9 +695,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -701,9 +832,9 @@
       }
     },
     "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -791,9 +922,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -841,9 +972,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -871,6 +1002,16 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
       }
     },
     "node_modules/ansi-regex": {
@@ -907,9 +1048,9 @@
       "license": "MIT"
     },
     "node_modules/app-builder-lib": {
-      "version": "26.7.0",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.7.0.tgz",
-      "integrity": "sha512-/UgCD8VrO79Wv8aBNpjMfsS1pIUfIPURoRn0Ik6tMe5avdZF+vQgl/juJgipcMmH3YS0BD573lCdCHyoi84USg==",
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.8.1.tgz",
+      "integrity": "sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -924,7 +1065,7 @@
         "@malept/flatpak-bundler": "^0.4.0",
         "@types/fs-extra": "9.0.13",
         "async-exit-hook": "^2.0.1",
-        "builder-util": "26.4.1",
+        "builder-util": "26.8.1",
         "builder-util-runtime": "9.5.1",
         "chromium-pickle-js": "^0.2.0",
         "ci-info": "4.3.1",
@@ -932,7 +1073,7 @@
         "dotenv": "^16.4.5",
         "dotenv-expand": "^11.0.6",
         "ejs": "^3.1.8",
-        "electron-publish": "26.6.0",
+        "electron-publish": "26.8.1",
         "fs-extra": "^10.1.0",
         "hosted-git-info": "^4.1.0",
         "isbinaryfile": "^5.0.0",
@@ -954,8 +1095,8 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "dmg-builder": "26.7.0",
-        "electron-builder-squirrel-windows": "26.7.0"
+        "dmg-builder": "26.8.1",
+        "electron-builder-squirrel-windows": "26.8.1"
       }
     },
     "node_modules/app-builder-lib/node_modules/@electron/get": {
@@ -1162,16 +1303,13 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
-      "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "jackspeak": "^4.2.3"
-      },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/base64-js": {
@@ -1256,16 +1394,16 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -1310,9 +1448,9 @@
       "license": "MIT"
     },
     "node_modules/builder-util": {
-      "version": "26.4.1",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.4.1.tgz",
-      "integrity": "sha512-FlgH43XZ50w3UtS1RVGDWOz8v9qMXPC7upMtKMtBEnYdt1OVoS61NYhKm/4x+cIaWqJTXua0+VVPI+fSPGXNIw==",
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.8.1.tgz",
+      "integrity": "sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1419,50 +1557,6 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/cacache/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cacache/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/cacache/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/cacache/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1471,21 +1565,14 @@
       "license": "MIT"
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
-    },
-    "node_modules/cacache/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cacache/node_modules/glob": {
       "version": "10.5.0",
@@ -1509,22 +1596,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/cacache/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/cacache/node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -1533,71 +1604,19 @@
       "license": "ISC"
     },
     "node_modules/cacache/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/cacache/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cacache/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/cacache/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -1848,9 +1867,9 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1918,6 +1937,15 @@
       "dependencies": {
         "buffer": "^5.1.0"
       }
+    },
+    "node_modules/cross-dirname": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2090,9 +2118,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2101,9 +2129,9 @@
       }
     },
     "node_modules/dir-compare/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2114,14 +2142,14 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "26.7.0",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.7.0.tgz",
-      "integrity": "sha512-uOOBA3f+kW3o4KpSoMQ6SNpdXU7WtxlJRb9vCZgOvqhTz4b3GjcoWKstdisizNZLsylhTMv8TLHFPFW0Uxsj/g==",
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.8.1.tgz",
+      "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.7.0",
-        "builder-util": "26.4.1",
+        "app-builder-lib": "26.8.1",
+        "builder-util": "26.8.1",
         "fs-extra": "^10.1.0",
         "iconv-lite": "^0.6.2",
         "js-yaml": "^4.1.0"
@@ -2194,32 +2222,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/dmg-license/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/dmg-license/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -2294,9 +2296,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "39.6.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-39.6.0.tgz",
-      "integrity": "sha512-KQK3sJ6JCyymY3HQxV0N/bVBQwKQETRW0N/+OYcrL9H6tZhpmTSaZY3qSxcruWrPIuouvoiP3Vk/JKUpw05ZIw==",
+      "version": "39.8.7",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.7.tgz",
+      "integrity": "sha512-B3TmzbUEeIvrhJ0QcoFp8/tgnVA3vsm0wkdYWzC22hsk9zTVqkzyrrz40cjd0nMTTIrGWxxfDO2tdQTCMe9Bjw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2312,18 +2314,18 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "26.7.0",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.7.0.tgz",
-      "integrity": "sha512-LoXbCvSFxLesPneQ/fM7FB4OheIDA2tjqCdUkKlObV5ZKGhYgi5VHPHO/6UUOUodAlg7SrkPx7BZJPby+Vrtbg==",
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.8.1.tgz",
+      "integrity": "sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.7.0",
-        "builder-util": "26.4.1",
+        "app-builder-lib": "26.8.1",
+        "builder-util": "26.8.1",
         "builder-util-runtime": "9.5.1",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
-        "dmg-builder": "26.7.0",
+        "dmg-builder": "26.8.1",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "simple-update-notifier": "2.0.0",
@@ -2338,15 +2340,15 @@
       }
     },
     "node_modules/electron-builder-squirrel-windows": {
-      "version": "26.7.0",
-      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.7.0.tgz",
-      "integrity": "sha512-3EqkQK+q0kGshdPSKEPb2p5F75TENMKu6Fe5aTdeaPfdzFK4Yjp5L0d6S7K8iyvqIsGQ/ei4bnpyX9wt+kVCKQ==",
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.8.1.tgz",
+      "integrity": "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "app-builder-lib": "26.7.0",
-        "builder-util": "26.4.1",
+        "app-builder-lib": "26.8.1",
+        "builder-util": "26.8.1",
         "electron-winstaller": "5.4.0"
       }
     },
@@ -2389,14 +2391,14 @@
       }
     },
     "node_modules/electron-publish": {
-      "version": "26.6.0",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.6.0.tgz",
-      "integrity": "sha512-LsyHMMqbvJ2vsOvuWJ19OezgF2ANdCiHpIucDHNiLhuI+/F3eW98ouzWSRmXXi82ZOPZXC07jnIravY4YYwCLQ==",
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.8.1.tgz",
+      "integrity": "sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "26.4.1",
+        "builder-util": "26.8.1",
         "builder-util-runtime": "9.5.1",
         "chalk": "^4.1.2",
         "form-data": "^4.0.5",
@@ -2696,12 +2698,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2711,15 +2713,6 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
-      }
-    },
-    "node_modules/express-rate-limit/node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/extract-zip": {
@@ -2757,13 +2750,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -2810,9 +2796,9 @@
       }
     },
     "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2827,9 +2813,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2837,9 +2823,9 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3093,9 +3079,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3104,9 +3090,9 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3271,9 +3257,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
-      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3443,7 +3429,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3517,19 +3502,19 @@
       "license": "ISC"
     },
     "node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
+        "@isaacs/cliui": "^8.0.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jake": {
@@ -3646,9 +3631,9 @@
       "license": "MIT"
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3815,16 +3800,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.0.tgz",
-      "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3841,11 +3826,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -3882,11 +3867,11 @@
       }
     },
     "node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -4002,9 +3987,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.26.0.tgz",
-      "integrity": "sha512-8QwIZqikRvDIkXS2S93LjzhsSPJuIbfaMETWH+Bx8oOT9Sa9UsUtBFQlc3gBNd1+QINjaTloitXr1W3dQLi9Iw==",
+      "version": "4.28.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.28.0.tgz",
+      "integrity": "sha512-Qfp5XZL1cJDOabOT8H5gnqMTmM4NjvYzHp4I/Kt/Sl76OVkOBBHRFlPspGV0hYvMoqQsypFjT/Yp7Km0beXW9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4340,9 +4325,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4378,9 +4363,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4412,6 +4397,36 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/proc-log": {
@@ -4482,20 +4497,10 @@
         "once": "^1.3.1"
       }
     },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -4743,9 +4748,9 @@
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
       "dev": true,
       "license": "WTFPL OR ISC",
       "dependencies": {
@@ -4753,9 +4758,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4886,13 +4891,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5182,9 +5187,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5293,14 +5298,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5423,16 +5428,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/utf8-byte-length": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentify/desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Agentify Desktop control center and MCP server for local AI web sessions",
   "license": "MPL-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "type": "module",
   "main": "main.mjs",
   "bin": {
-    "agentify-desktop": "./bin/agentify-desktop.mjs",
-    "agentify-desktop-gui": "./bin/agentify-desktop.mjs",
-    "agentify-desktop-mcp": "./bin/agentify-desktop.mjs"
+    "agentify-desktop": "bin/agentify-desktop.mjs",
+    "agentify-desktop-gui": "bin/agentify-desktop.mjs",
+    "agentify-desktop-mcp": "bin/agentify-desktop.mjs"
   },
   "files": [
     "README.md",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,43 @@
 {
-  "name": "agentify-desktop",
-  "private": true,
+  "name": "@agentify/desktop",
   "version": "0.1.0",
+  "description": "Agentify Desktop control center and MCP server for local AI web sessions",
+  "license": "MIT",
   "type": "module",
   "main": "main.mjs",
+  "bin": {
+    "agentify-desktop": "./bin/agentify-desktop.mjs",
+    "agentify-desktop-gui": "./bin/agentify-desktop.mjs",
+    "agentify-desktop-mcp": "./bin/agentify-desktop.mjs"
+  },
+  "files": [
+    "README.md",
+    "SECURITY.md",
+    "TRADEMARKS.md",
+    "artifact-store.mjs",
+    "browser-backend.mjs",
+    "bundle-store.mjs",
+    "chatgpt-controller.mjs",
+    "chrome-cdp-backend.mjs",
+    "config.mjs",
+    "context-packer.mjs",
+    "electron-browser-backend.mjs",
+    "http-api.mjs",
+    "main.mjs",
+    "mcp-lib.mjs",
+    "mcp-server.mjs",
+    "orchestrator.mjs",
+    "orchestrator/",
+    "popup-policy.mjs",
+    "selectors.json",
+    "shutdown.mjs",
+    "state.mjs",
+    "tab-manager.mjs",
+    "ui/",
+    "vendors.json",
+    "watch-folder.mjs",
+    "bin/"
+  ],
   "scripts": {
     "start": "electron .",
     "mcp": "node mcp-server.mjs",
@@ -12,15 +46,22 @@
     "dist": "electron-builder"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0",
-    "electron": "^39.6.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "electron": "^39.8.7",
     "zod": "^3.22.3"
   },
   "devDependencies": {
-    "electron-builder": "^26.7.0"
+    "electron-builder": "^26.8.1"
   },
   "overrides": {
-    "hono": "^4.11.7"
+    "@hono/node-server": "^1.19.14",
+    "ajv": "^8.18.0",
+    "express-rate-limit": "^8.3.2",
+    "hono": "^4.12.14",
+    "path-to-regexp": "^8.4.2"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "build": {
     "appId": "com.agentify.desktop",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@agentify/desktop",
   "version": "0.1.0",
   "description": "Agentify Desktop control center and MCP server for local AI web sessions",
-  "license": "MIT",
+  "license": "MPL-2.0",
   "type": "module",
   "main": "main.mjs",
   "bin": {

--- a/tests/package-manifest.test.mjs
+++ b/tests/package-manifest.test.mjs
@@ -14,9 +14,9 @@ test('package manifest is publishable under @agentify/desktop with npx-friendly 
   assert.equal(manifest.name, '@agentify/desktop');
   assert.equal(manifest.private, undefined);
   assert.equal(manifest.publishConfig?.access, 'public');
-  assert.equal(manifest.bin?.['agentify-desktop'], './bin/agentify-desktop.mjs');
-  assert.equal(manifest.bin?.['agentify-desktop-gui'], './bin/agentify-desktop.mjs');
-  assert.equal(manifest.bin?.['agentify-desktop-mcp'], './bin/agentify-desktop.mjs');
+  assert.equal(manifest.bin?.['agentify-desktop'], 'bin/agentify-desktop.mjs');
+  assert.equal(manifest.bin?.['agentify-desktop-gui'], 'bin/agentify-desktop.mjs');
+  assert.equal(manifest.bin?.['agentify-desktop-mcp'], 'bin/agentify-desktop.mjs');
   assert.ok(manifest.files.includes('bin/'));
   assert.ok(manifest.files.includes('main.mjs'));
   assert.ok(manifest.files.includes('mcp-server.mjs'));

--- a/tests/package-manifest.test.mjs
+++ b/tests/package-manifest.test.mjs
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const root = path.resolve(__dirname, '..');
+
+test('package manifest is publishable under @agentify/desktop with npx-friendly bins', async () => {
+  const manifest = JSON.parse(await fs.readFile(path.join(root, 'package.json'), 'utf8'));
+
+  assert.equal(manifest.name, '@agentify/desktop');
+  assert.equal(manifest.private, undefined);
+  assert.equal(manifest.publishConfig?.access, 'public');
+  assert.equal(manifest.bin?.['agentify-desktop'], './bin/agentify-desktop.mjs');
+  assert.equal(manifest.bin?.['agentify-desktop-gui'], './bin/agentify-desktop.mjs');
+  assert.equal(manifest.bin?.['agentify-desktop-mcp'], './bin/agentify-desktop.mjs');
+  assert.ok(manifest.files.includes('bin/'));
+  assert.ok(manifest.files.includes('main.mjs'));
+  assert.ok(manifest.files.includes('mcp-server.mjs'));
+  assert.ok(manifest.files.includes('ui/'));
+  assert.ok(!manifest.files.includes('tests/'));
+});
+
+test('desktop bin dispatches gui and mcp modes', async () => {
+  const bin = await fs.readFile(path.join(root, 'bin', 'agentify-desktop.mjs'), 'utf8');
+
+  assert.ok(bin.startsWith('#!/usr/bin/env node'));
+  assert.ok(bin.includes("first === 'mcp'"));
+  assert.ok(bin.includes("first === 'gui'"));
+  assert.ok(bin.includes("'mcp-server.mjs'"));
+  assert.ok(bin.includes("'electron'"));
+});
+
+test('public README documents npm package and registered MCP tool names', async () => {
+  const readme = await fs.readFile(path.join(root, 'README.md'), 'utf8');
+
+  assert.match(readme, /npx @agentify\/desktop/);
+  assert.match(readme, /agentify_tabs/);
+  assert.match(readme, /agentify_tab_create/);
+  assert.match(readme, /agentify_tab_close/);
+  assert.doesNotMatch(readme, /agentify_create_tab/);
+  assert.doesNotMatch(readme, /agentify-sh/);
+});


### PR DESCRIPTION
## Summary
- rename the npm package to @agentify/desktop and expose npx/global launcher bins
- add the agentify-desktop dispatcher for GUI and MCP modes
- refresh public README docs around install, MCP registration, workflows, privacy, and package commands
- lock dependency updates and overrides so npm audit is clean
- add manifest/README regression tests for package publish readiness

## Validation
- npm test
- npm audit
- npm audit --omit=dev
- node ./bin/agentify-desktop.mjs --help
- npm pack --dry-run --json
- secret/legacy reference scan with rg over tracked source excluding .git, node_modules, and package-lock.json

## Not Included
- no npm publish
- no installer build
- no Playwright/browser GUI run