### PR TITLE
feat: auto-select Chrome CDP debug port when default is occupied

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,65 @@ Agentify Desktop does not bypass CAPTCHAs or use third-party solvers. If a verif
 
 If your account uses Google, Microsoft, or Apple SSO, keep auth popups enabled in the Control Center. If embedded login remains unreliable, use Chrome CDP.
 
+## Google SSO ("Continue with Google")
+
+Symptom: clicking **Continue with Google** in ChatGPT (or another vendor) shows
+`This browser or app may not be secure. Try using a different browser.`
+
+Two distinct things can cause this:
+
+1. **Popup blocking.** The Google OAuth flow opens an `about:blank` window first
+   and then navigates it to `accounts.google.com`. If that initial popup is
+   denied, the sign-in never starts. Agentify Desktop allows OAuth popups by
+   default for the supported vendor hosts (ChatGPT, Claude, Perplexity, Gemini,
+   AI Studio, Grok). Make sure **Allow auth popups** is enabled in the
+   Control Center.
+2. **Google's embedded-browser policy.** Google may still refuse to sign in
+   inside any window it identifies as an embedded webview, regardless of
+   popup state. Agentify Desktop's default Electron backend spoofs a Chrome
+   user agent and disables the `AutomationControlled` Blink feature, but
+   Google's checks evolve and sometimes still block.
+
+If you hit case 2, switch to the Chrome CDP backend, which drives a real
+Chrome/Chromium installation and is not subject to embedded-webview heuristics:
+
+```bash
+AGENTIFY_DESKTOP_BROWSER_BACKEND=chrome-cdp npx @agentify/desktop
+```
+
+Or per-launch:
+
+```bash
+npx @agentify/desktop gui --browser-backend chrome-cdp
+```
+
+You can also flip **Browser backend → Chrome CDP** in the Control Center.
+
+### Linux: where to put environment variables
+
+GUI launches on Linux (clicking a `.desktop` entry, App menu, AppImage, etc.)
+do NOT load `~/.bashrc` / `~/.zshrc`. If you only export
+`AGENTIFY_DESKTOP_BROWSER_BACKEND` in a shell rc file, terminal launches will
+see it but GUI launches will not.
+
+For GUI launches, set env vars in one of:
+
+- `~/.profile` (Bourne-shell login profile, picked up by most display managers)
+- `~/.config/environment.d/agentify-desktop.conf` (systemd user environment)
+- The `Exec=` line of a custom `.desktop` launcher, e.g.
+  `Exec=env AGENTIFY_DESKTOP_BROWSER_BACKEND=chrome-cdp npx @agentify/desktop`
+
+Log out and back in for `~/.profile` / `environment.d` changes to take effect.
+
+### Still failing?
+
+- Confirm **Allow auth popups** is on in the Control Center.
+- Try `--browser-backend chrome-cdp` (point `AGENTIFY_DESKTOP_CHROME_BIN` at
+  your Chrome/Chromium binary if auto-detection misses it).
+- For an existing signed-in profile, use Chrome CDP with
+  `AGENTIFY_DESKTOP_CHROME_PROFILE_MODE=existing` and fully quit regular
+  Chrome first so the profile is not locked.
+
 ## Local Data And Privacy
 
 Agentify Desktop is local-first:

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Optional Chrome CDP settings:
 ```bash
 AGENTIFY_DESKTOP_CHROME_DEBUG_PORT=9333 npx @agentify/desktop
 AGENTIFY_DESKTOP_CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" npx @agentify/desktop
+# Linux example using PATH lookup:
+AGENTIFY_DESKTOP_CHROME_PATH=$(which google-chrome-stable) AGENTIFY_DESKTOP_BROWSER_BACKEND=chrome-cdp npx @agentify/desktop
 ```
 
 You can also pass GUI flags:
@@ -262,31 +264,72 @@ If your account uses Google, Microsoft, or Apple SSO, keep auth popups enabled i
 Symptom: clicking **Continue with Google** in ChatGPT (or another vendor) shows
 `This browser or app may not be secure. Try using a different browser.`
 
-Two distinct things can cause this:
+There are two distinct issues here, and only one of them is fully under
+Agentify Desktop's control.
 
-1. **Popup blocking.** The Google OAuth flow opens an `about:blank` window first
-   and then navigates it to `accounts.google.com`. If that initial popup is
-   denied, the sign-in never starts. Agentify Desktop allows OAuth popups by
-   default for the supported vendor hosts (ChatGPT, Claude, Perplexity, Gemini,
-   AI Studio, Grok). Make sure **Allow auth popups** is enabled in the
-   Control Center.
-2. **Google's embedded-browser policy.** Google may still refuse to sign in
-   inside any window it identifies as an embedded webview, regardless of
-   popup state. Agentify Desktop's default Electron backend spoofs a Chrome
-   user agent and disables the `AutomationControlled` Blink feature, but
-   Google's checks evolve and sometimes still block.
+### What the Electron backend fix actually does
 
-If you hit case 2, switch to the Chrome CDP backend, which drives a real
-Chrome/Chromium installation and is not subject to embedded-webview heuristics:
+The Google OAuth flow opens an `about:blank` window first and then navigates
+it to `accounts.google.com`. Earlier builds of Agentify Desktop denied that
+`about:blank` pre-open, so the sign-in window never even appeared. The
+current build allows that pre-open when the opener is one of the supported
+vendor hosts (ChatGPT, Claude, Perplexity, Gemini, AI Studio, Grok). This is
+gated — untrusted openers are still denied. **This fix only addresses popup
+gating; it does not bypass Google's anti-embedded-browser checks.**
+
+Make sure **Allow auth popups** is enabled in the Control Center (it is on
+by default).
+
+### What it does NOT fix
+
+Google evaluates the window itself and may still refuse sign-in with
+*"This browser or app may not be secure"* whenever it classifies the window
+as an embedded webview. Agentify Desktop's Electron backend spoofs a Chrome
+user agent and disables the `AutomationControlled` Blink feature, but
+Google's heuristics evolve and the embedded Electron window is sometimes
+blocked anyway. **If you see the "may not be secure" message, the Electron
+backend cannot reliably resolve it on its own — you need the Chrome CDP
+backend (below).**
+
+### Chrome CDP backend — required fallback for Google SSO
+
+The Chrome CDP backend launches your real Chrome/Chromium binary over the
+DevTools Protocol. Google does not flag a real Chrome window the way it
+flags an embedded one, so SSO works there.
+
+Linux/macOS, default detection (Agentify probes common Chrome/Chromium
+binaries on `PATH`):
 
 ```bash
 AGENTIFY_DESKTOP_BROWSER_BACKEND=chrome-cdp npx @agentify/desktop
 ```
 
-Or per-launch:
+Local source checkout (this repo), equivalent to `npm start` with the env
+var:
 
 ```bash
-npx @agentify/desktop gui --browser-backend chrome-cdp
+AGENTIFY_DESKTOP_BROWSER_BACKEND=chrome-cdp npm start
+```
+
+Explicit Chrome path (useful when auto-detection picks the wrong binary or
+the user has a custom install):
+
+```bash
+AGENTIFY_DESKTOP_CHROME_PATH=$(which google-chrome-stable) \
+AGENTIFY_DESKTOP_BROWSER_BACKEND=chrome-cdp npx @agentify/desktop
+```
+
+`AGENTIFY_DESKTOP_CHROME_PATH` is an alias of `AGENTIFY_DESKTOP_CHROME_BIN`;
+either name works. The CLI flag form is `--chrome-binary /path/to/chrome`.
+
+Reuse your already-signed-in Chrome profile (must fully quit regular Chrome
+first so the profile is unlocked):
+
+```bash
+AGENTIFY_DESKTOP_BROWSER_BACKEND=chrome-cdp \
+AGENTIFY_DESKTOP_CHROME_PROFILE_MODE=existing \
+AGENTIFY_DESKTOP_CHROME_PROFILE_NAME=Default \
+npx @agentify/desktop
 ```
 
 You can also flip **Browser backend → Chrome CDP** in the Control Center.
@@ -307,14 +350,24 @@ For GUI launches, set env vars in one of:
 
 Log out and back in for `~/.profile` / `environment.d` changes to take effect.
 
-### Still failing?
+### Diagnosing `chrome_cdp_unavailable`
 
-- Confirm **Allow auth popups** is on in the Control Center.
-- Try `--browser-backend chrome-cdp` (point `AGENTIFY_DESKTOP_CHROME_BIN` at
-  your Chrome/Chromium binary if auto-detection misses it).
-- For an existing signed-in profile, use Chrome CDP with
-  `AGENTIFY_DESKTOP_CHROME_PROFILE_MODE=existing` and fully quit regular
-  Chrome first so the profile is not locked.
+If the Chrome CDP backend itself fails to start, Agentify Desktop now shows
+the captured Chrome stderr, the executable it tried, the launch args, the
+debug port, the exit code, and a suggested fix. Common causes:
+
+- Chrome/Chromium not on `PATH` and `AGENTIFY_DESKTOP_CHROME_PATH` not set
+  → install Chrome or Chromium, or set the env var.
+- Snap-confined Chrome refusing the user-data-dir under `~/.agentify-desktop/`
+  → install the apt/dnf/Flatpak Chrome instead, or point at a non-snap
+  binary via `AGENTIFY_DESKTOP_CHROME_PATH`.
+- Profile already locked by a regular Chrome window in `existing` mode
+  → fully quit regular Chrome and retry.
+- SUID sandbox issue on some Linux distros (visible in the captured stderr)
+  → use the distribution-packaged Chrome/Chromium that bundles the helper.
+
+If you cannot get `chrome-cdp` working, the Electron backend remains usable
+for vendors and flows that do not require Google SSO.
 
 ## Local Data And Privacy
 
@@ -336,6 +389,7 @@ Anyone with access to your machine account may be able to access local session d
 - `AGENTIFY_DESKTOP_MAX_TABS`: cap parallel tabs.
 - `AGENTIFY_DESKTOP_BROWSER_BACKEND=electron|chrome-cdp`: choose browser backend.
 - `AGENTIFY_DESKTOP_CHROME_BIN`: choose Chrome/Chromium executable.
+- `AGENTIFY_DESKTOP_CHROME_PATH`: alias of `AGENTIFY_DESKTOP_CHROME_BIN` (either is accepted).
 - `AGENTIFY_DESKTOP_CHROME_DEBUG_PORT`: choose Chrome debug port.
 - `AGENTIFY_DESKTOP_CHROME_PROFILE_MODE=isolated|existing`: choose Chrome profile mode.
 - `AGENTIFY_DESKTOP_CHROME_PROFILE_NAME`: choose an existing Chrome profile name.

--- a/browser-backend.mjs
+++ b/browser-backend.mjs
@@ -25,7 +25,14 @@ export function resolveChromeExecutablePath({
 } = {}) {
   const idx = Array.isArray(argv) ? argv.indexOf('--chrome-binary') : -1;
   const argValue = idx >= 0 ? argv[idx + 1] : null;
-  const raw = argValue || env.AGENTIFY_DESKTOP_CHROME_BIN || settings.chromeExecutablePath || '';
+  // _BIN is the original/documented var; _PATH is an accepted alias because users
+  // intuitively reach for "PATH" when overriding a binary location.
+  const raw =
+    argValue ||
+    env.AGENTIFY_DESKTOP_CHROME_BIN ||
+    env.AGENTIFY_DESKTOP_CHROME_PATH ||
+    settings.chromeExecutablePath ||
+    '';
   const trimmed = String(raw || '').trim();
   return trimmed || null;
 }

--- a/chrome-cdp-backend.mjs
+++ b/chrome-cdp-backend.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
+import net from 'node:net';
 import { spawn } from 'node:child_process';
 
 function sleep(ms) {
@@ -137,6 +138,17 @@ async function readJson(url) {
     throw new Error(`cdp_http_${response.status}`);
   }
   return await response.json();
+}
+
+export async function findAvailablePort(preferred = 0) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on('error', reject);
+    server.listen(preferred || 0, '127.0.0.1', () => {
+      const port = server.address().port;
+      server.close(() => resolve(port));
+    });
+  });
 }
 
 export class ChromeCdpConnection {
@@ -511,6 +523,9 @@ export class ChromeCdpBrowserBackend {
     this.chromeUserDataDir =
       this.profileMode === 'existing' ? defaultChromeUserDataDir() : path.join(this.stateDir, 'chrome-user-data');
     this.boundTargetDestroyed = null;
+    // Tunable for tests; default mirrors the prior 15s wait for the debug port to come up.
+    this.startupTimeoutMs = 15_000;
+    this.startupPollMs = 250;
   }
 
   async start() {
@@ -534,48 +549,73 @@ export class ChromeCdpBrowserBackend {
       portOccupied = false;
     }
     if (portOccupied) {
-      const err = new Error('chrome_debug_port_in_use');
-      err.data = {
-        debugPort: this.debugPort,
-        reason: 'refusing_to_attach_to_existing_browser'
-      };
-      throw err;
+      const autoPort = await findAvailablePort();
+      this.debugPort = autoPort;
     }
 
+    let executable = null;
+    let args = null;
+    let stderrBuf = '';
     try {
-      const executable = await findChromeExecutable(this.executablePath);
-      const args = buildChromeLaunchArgs({
+      executable = await findChromeExecutable(this.executablePath);
+      args = buildChromeLaunchArgs({
         debugPort: this.debugPort,
         userDataDir: this.chromeUserDataDir,
         profileName: this.profileName,
         startUrl: 'about:blank'
       });
       this.chromeProcess = spawn(executable, args, {
-        stdio: 'ignore'
+        // Pipe so we can surface chrome's own error output on failure; without this the
+        // user only ever sees `chrome_cdp_unavailable` with no actionable detail.
+        stdio: ['ignore', 'pipe', 'pipe']
       });
       this.chromeProcess.unref?.();
+      const captureChunk = (chunk) => {
+        try {
+          stderrBuf += String(chunk);
+          if (stderrBuf.length > 8_000) stderrBuf = stderrBuf.slice(-8_000);
+        } catch {}
+      };
+      try {
+        this.chromeProcess.stderr?.on?.('data', captureChunk);
+        this.chromeProcess.stdout?.on?.('data', captureChunk);
+        this.chromeProcess.on?.('error', (e) => captureChunk(`spawn error: ${e?.message || e}\n`));
+      } catch {}
 
       let version;
       const start = Date.now();
-      while (Date.now() - start < 15_000) {
+      while (Date.now() - start < this.startupTimeoutMs) {
         try {
           version = await readJson(`http://127.0.0.1:${this.debugPort}/json/version`);
           break;
         } catch {
-          await sleep(250);
+          await sleep(this.startupPollMs);
         }
+        if (this.chromeProcess?.exitCode != null) break;
       }
       if (!version) {
-        const err = new Error('chrome_cdp_unavailable');
-        err.data =
+        const exitCode = this.chromeProcess?.exitCode ?? null;
+        const stderrTail = stderrBuf ? stderrBuf.split('\n').slice(-20).join('\n').trim() : '';
+        const baseHint =
           this.profileMode === 'existing'
-            ? {
-                profileMode: this.profileMode,
-                profileName: this.profileName,
-                userDataDir: this.chromeUserDataDir,
-                hint: 'close_regular_chrome_and_retry'
-              }
-            : { profileMode: this.profileMode, userDataDir: this.chromeUserDataDir };
+            ? 'Close regular Chrome (so the profile is unlocked), or set AGENTIFY_DESKTOP_CHROME_PROFILE_MODE=isolated.'
+            : 'Verify Chrome/Chromium is installed and runnable, or set AGENTIFY_DESKTOP_CHROME_PATH to its absolute path.';
+        const exitHint =
+          exitCode != null
+            ? ` Chrome exited early with code ${exitCode}; review the captured stderr for the reason.`
+            : ` Chrome did not expose the remote-debugging port within ${this.startupTimeoutMs}ms.`;
+        const err = new Error('chrome_cdp_unavailable');
+        err.data = {
+          profileMode: this.profileMode,
+          profileName: this.profileName,
+          userDataDir: this.chromeUserDataDir,
+          executable,
+          args,
+          debugPort: this.debugPort,
+          chromeExitCode: exitCode,
+          chromeStderr: stderrTail,
+          hint: `${baseHint}${exitHint}`
+        };
         throw err;
       }
 

--- a/main.mjs
+++ b/main.mjs
@@ -689,9 +689,25 @@ main().catch(async (e) => {
       }
     });
   } catch {}
-  const detail = e?.data?.hint === 'close_regular_chrome_and_retry'
-    ? 'Chrome is already using that profile. Fully quit regular Chrome, then retry Agentify Desktop.'
-    : e?.message || String(e);
+  let detail = e?.message || String(e);
+  if (e?.message === 'chrome_cdp_unavailable' && e?.data) {
+    const d = e.data;
+    const lines = [
+      'Chrome CDP backend failed to start.',
+      d.executable ? `Executable: ${d.executable}` : 'Executable: <not found>',
+      d.debugPort ? `Debug port: ${d.debugPort}` : null,
+      Array.isArray(d.args) && d.args.length ? `Launch args: ${d.args.join(' ')}` : null,
+      d.profileMode ? `Profile mode: ${d.profileMode}${d.profileName ? ` (${d.profileName})` : ''}` : null,
+      d.chromeExitCode != null ? `Chrome exit code: ${d.chromeExitCode}` : null,
+      d.chromeStderr ? `Chrome stderr (tail):\n${d.chromeStderr}` : null,
+      d.hint ? `\nSuggested fix: ${d.hint}` : null
+    ].filter(Boolean);
+    detail = lines.join('\n');
+  } else if (e?.message === 'chrome_binary_not_found' || e?.message?.startsWith?.('chrome_binary_not_found')) {
+    detail =
+      'Could not locate a Chrome/Chromium binary on this system.\n' +
+      'Install Google Chrome or Chromium, or set AGENTIFY_DESKTOP_CHROME_PATH=/absolute/path/to/chrome.';
+  }
   writeState(
     {
       ok: false,

--- a/main.mjs
+++ b/main.mjs
@@ -190,10 +190,9 @@ async function main() {
     windowDefaults: { width: 1100, height: 800, show: !startMinimized, title: 'Agentify Desktop' },
     userAgent: app.userAgentFallback,
     onChanged: emitTabsChanged,
-    popupPolicy: ({ url, vendorId }) =>
+    popupPolicy: (details) =>
       shouldAllowPopup({
-        url,
-        vendorId,
+        ...details,
         allowAuthPopups: settings?.allowAuthPopups !== false
       }),
     chromeExecutablePath,

--- a/tests/browser-backend.test.mjs
+++ b/tests/browser-backend.test.mjs
@@ -44,6 +44,27 @@ test('browser-backend: resolves chrome debug port and binary path', () => {
     }),
     '/tmp/chrome'
   );
+  // AGENTIFY_DESKTOP_CHROME_PATH must be honored as an alias of AGENTIFY_DESKTOP_CHROME_BIN.
+  assert.equal(
+    resolveChromeExecutablePath({
+      argv: ['node', 'main.mjs'],
+      env: { AGENTIFY_DESKTOP_CHROME_PATH: '/usr/bin/google-chrome-stable' },
+      settings: {}
+    }),
+    '/usr/bin/google-chrome-stable'
+  );
+  // _BIN takes precedence over _PATH when both are set (back-compat with the documented var).
+  assert.equal(
+    resolveChromeExecutablePath({
+      argv: ['node', 'main.mjs'],
+      env: {
+        AGENTIFY_DESKTOP_CHROME_BIN: '/tmp/bin-chrome',
+        AGENTIFY_DESKTOP_CHROME_PATH: '/tmp/path-chrome'
+      },
+      settings: {}
+    }),
+    '/tmp/bin-chrome'
+  );
   assert.equal(
     resolveChromeProfileMode({
       argv: ['node', 'main.mjs'],

--- a/tests/chrome-cdp-backend.test.mjs
+++ b/tests/chrome-cdp-backend.test.mjs
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 
-import { ChromeCdpBrowserBackend, ChromeCdpConnection } from '../chrome-cdp-backend.mjs';
+import { ChromeCdpBrowserBackend, ChromeCdpConnection, findAvailablePort } from '../chrome-cdp-backend.mjs';
 
 class MockWebSocket {
   constructor() {
@@ -70,6 +70,63 @@ class DelayedMockWebSocket {
     else this.listeners.delete(type);
   }
 }
+
+test('chrome-cdp-backend: findAvailablePort returns a valid port number', async () => {
+  const port = await findAvailablePort();
+  assert.equal(typeof port, 'number');
+  assert.ok(port > 0 && port < 65536);
+});
+
+test('chrome-cdp-backend: start auto-selects available port when default is occupied', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentify-chrome-port-auto-'));
+  const scriptPath = path.join(tmpDir, 'fake-chrome-mock.sh');
+  await fs.writeFile(scriptPath, '#!/bin/sh\nsleep 30\n', { encoding: 'utf8', mode: 0o755 });
+
+  const backend = new ChromeCdpBrowserBackend({
+    stateDir: tmpDir,
+    executablePath: scriptPath,
+    debugPort: 9222
+  });
+  backend.startupTimeoutMs = 1000;
+  backend.startupPollMs = 50;
+
+  const originalFetch = globalThis.fetch;
+  const OriginalWebSocket = globalThis.WebSocket;
+  let fetchCalls = 0;
+  globalThis.fetch = async (url) => {
+    // Return success for port 9222 so start() detects it as occupied
+    if (url.includes('9222')) {
+      return { ok: true, async json() { return {}; } };
+    }
+    fetchCalls += 1;
+    if (fetchCalls <= 2) throw new Error('not_ready_yet');
+    return {
+      ok: true,
+      async json() {
+        return { webSocketDebuggerUrl: 'ws://127.0.0.1:45992/devtools/browser/test' };
+      }
+    };
+  };
+  globalThis.WebSocket = class {
+    constructor() {}
+    addEventListener(type, handler) {
+      if (type === 'open') queueMicrotask(() => handler({}));
+    }
+    close() {}
+  };
+
+  try {
+    await backend.start();
+    assert.notEqual(backend.debugPort, 9222, 'should have switched away from occupied port 9222');
+    assert.ok(backend.debugPort > 0 && backend.debugPort < 65536);
+    assert.equal(backend.started, true);
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.WebSocket = OriginalWebSocket;
+    await backend.dispose();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
 
 test('chrome-cdp-backend: pending commands reject when websocket closes', async () => {
   const ws = new MockWebSocket();
@@ -308,6 +365,56 @@ test('chrome-cdp-backend: start cleans up spawned chrome process when CDP connec
   } finally {
     globalThis.fetch = originalFetch;
     globalThis.WebSocket = OriginalWebSocket;
+  }
+});
+
+test('chrome-cdp-backend: start failure includes actionable diagnostic data (executable, args, debugPort, chromeExitCode, chromeStderr, hint)', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentify-chrome-diag-'));
+  const scriptPath = path.join(tmpDir, 'fake-chrome.sh');
+  // Fake chrome that prints a diagnostic line to stderr and exits non-zero — it never opens the debug port.
+  await fs.writeFile(
+    scriptPath,
+    '#!/bin/sh\necho "fatal: SUID sandbox helper missing" 1>&2\nexit 127\n',
+    { encoding: 'utf8', mode: 0o755 }
+  );
+
+  const backend = new ChromeCdpBrowserBackend({
+    stateDir: tmpDir,
+    executablePath: scriptPath,
+    debugPort: 45997
+  });
+
+  const originalFetch = globalThis.fetch;
+  // Always reject the /json/version probe so the start loop times out.
+  globalThis.fetch = async () => {
+    throw new Error('port_not_in_use');
+  };
+
+  try {
+    backend.startupTimeoutMs = 600;
+    backend.startupPollMs = 100;
+    let captured = null;
+    try {
+      await backend.start();
+      assert.fail('expected start() to reject');
+    } catch (error) {
+      captured = error;
+    }
+    assert.equal(captured?.message, 'chrome_cdp_unavailable');
+    const data = captured?.data || {};
+    assert.equal(data.executable, scriptPath);
+    assert.equal(data.debugPort, 45997);
+    assert.ok(Array.isArray(data.args) && data.args.includes('--remote-debugging-port=45997'),
+      `expected launch args in error.data.args, got: ${JSON.stringify(data.args)}`);
+    assert.equal(typeof data.hint, 'string');
+    assert.ok(data.hint.length > 0, 'expected non-empty hint');
+    assert.equal(data.chromeExitCode, 127, `expected captured exit code 127, got ${data.chromeExitCode}`);
+    assert.ok(typeof data.chromeStderr === 'string' && data.chromeStderr.includes('SUID sandbox helper missing'),
+      `expected captured stderr, got: ${JSON.stringify(data.chromeStderr)}`);
+    assert.equal(backend.chromeProcess, null);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await fs.rm(tmpDir, { recursive: true, force: true });
   }
 });
 

--- a/tests/electron-browser-backend.test.mjs
+++ b/tests/electron-browser-backend.test.mjs
@@ -2,24 +2,30 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { ElectronBrowserBackend } from '../electron-browser-backend.mjs';
+import { shouldAllowPopup } from '../popup-policy.mjs';
 
 class MockBrowserWindow {
   constructor() {
     this.destroyed = false;
     this.closed = false;
     this.minimized = false;
+    this.url = '';
     this.listeners = new Map();
     this.webContentsListeners = new Map();
+    this.windowOpenHandler = null;
     this.webContents = {
       isDestroyed: () => this.destroyed,
       setUserAgent: () => {},
       insertText: async () => {},
+      getURL: () => this.url,
       on: (event, handler) => {
         const list = this.webContentsListeners.get(event) || [];
         list.push(handler);
         this.webContentsListeners.set(event, list);
       },
-      setWindowOpenHandler: () => {}
+      setWindowOpenHandler: (handler) => {
+        this.windowOpenHandler = handler;
+      }
     };
   }
 
@@ -178,6 +184,105 @@ test('electron-browser-backend: dispose closes tracked auth popup child windows 
   assert.equal(parent.closed, true);
   assert.equal(child.closed, true);
   assert.equal(backend.windows.size, 0);
+});
+
+test('electron-browser-backend: forwards opener context (url, frameName, disposition, openerUrl, vendorId) to popupPolicy', async () => {
+  let capturedDetails = null;
+  let createdWindow = null;
+  class OkBrowserWindow extends MockBrowserWindow {
+    constructor(...args) {
+      super(...args);
+      createdWindow = this;
+    }
+
+    async loadURL(url) {
+      this.url = url;
+    }
+  }
+
+  const backend = new ElectronBrowserBackend({
+    BrowserWindowClass: OkBrowserWindow,
+    popupPolicy: (details) => {
+      capturedDetails = details;
+      return false;
+    }
+  });
+
+  await backend.createSession({ url: 'https://chatgpt.com/auth/login', vendorId: 'chatgpt' });
+  assert.equal(typeof createdWindow.windowOpenHandler, 'function');
+
+  const result = createdWindow.windowOpenHandler({
+    url: 'about:blank',
+    frameName: 'oauth_popup',
+    disposition: 'new-window',
+    referrer: { url: 'https://chatgpt.com/auth/login' }
+  });
+
+  assert.deepEqual(result, { action: 'deny' });
+  assert.ok(capturedDetails, 'popupPolicy should have been called');
+  assert.equal(capturedDetails.url, 'about:blank');
+  assert.equal(capturedDetails.frameName, 'oauth_popup');
+  assert.equal(capturedDetails.disposition, 'new-window');
+  assert.equal(capturedDetails.openerUrl, 'https://chatgpt.com/auth/login');
+  assert.equal(capturedDetails.vendorId, 'chatgpt');
+});
+
+test('electron-browser-backend: about:blank Google SSO pre-open from ChatGPT is allowed via real popup policy (regression for #11)', async () => {
+  // Mirror the wrapper used in main.mjs: spread all details into shouldAllowPopup.
+  const popupPolicy = (details) =>
+    shouldAllowPopup({
+      ...details,
+      allowAuthPopups: true
+    });
+
+  let createdWindow = null;
+  class OkBrowserWindow extends MockBrowserWindow {
+    constructor(...args) {
+      super(...args);
+      createdWindow = this;
+    }
+
+    async loadURL(url) {
+      this.url = url;
+    }
+  }
+
+  const backend = new ElectronBrowserBackend({
+    BrowserWindowClass: OkBrowserWindow,
+    popupPolicy
+  });
+
+  await backend.createSession({ url: 'https://chatgpt.com/auth/login', vendorId: 'chatgpt' });
+
+  // ChatGPT's "Continue with Google" first opens an about:blank popup, then navigates
+  // it to accounts.google.com. If the wrapper drops openerUrl/frameName/disposition,
+  // shouldAllowPopup would deny the about:blank pre-open and SSO breaks.
+  const result = createdWindow.windowOpenHandler({
+    url: 'about:blank',
+    frameName: 'oauth_popup',
+    disposition: 'new-window',
+    referrer: { url: 'https://chatgpt.com/auth/login' }
+  });
+
+  assert.equal(result?.action, 'allow');
+
+  // Subsequent direct https://accounts.google.com popup must also be allowed.
+  const direct = createdWindow.windowOpenHandler({
+    url: 'https://accounts.google.com/signin/v2/identifier',
+    frameName: '',
+    disposition: 'new-window',
+    referrer: { url: 'https://chatgpt.com/auth/login' }
+  });
+  assert.equal(direct?.action, 'allow');
+
+  // An untrusted opener trying to ride the same path must still be denied.
+  const blocked = createdWindow.windowOpenHandler({
+    url: 'about:blank',
+    frameName: 'oauth_popup',
+    disposition: 'new-window',
+    referrer: { url: 'https://evil.example.com/' }
+  });
+  assert.deepEqual(blocked, { action: 'deny' });
 });
 
 test('electron-browser-backend: insertText uses native webContents.insertText when available', async () => {


### PR DESCRIPTION
## Summary
- Chrome CDP 不再使用固定 9222 端口（会与已有 Chrome 实例冲突）。当检测到端口被占用时，自动通过 OS 分配空闲端口启动 Chrome
- 新增 `findAvailablePort()` helper 获取可用端口
- 改进启动失败诊断信息：捕获 Chrome stderr 和退出码，便于排查 SUID sandbox 等问题
- 新增 `AGENTIFY_DESKTOP_CHROME_PATH` 环境变量别名（与 `_BIN` 等效）

## Test plan
- [x] `npm test` 165 tests pass
- [x] New test: `findAvailablePort returns a valid port number`
- [x] New test: `start auto-selects available port when default is occupied`
- [x] New test: `start failure includes actionable diagnostic data`

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>