### PR TITLE
[codex] Make Chrome CDP default and fix vendor tab reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,13 +223,13 @@ The tool result includes `packedContextSummary` so you can see what was included
 
 Agentify Desktop supports two browser backends:
 
-- `electron`: embedded windows managed by Agentify Desktop. This is the default.
-- `chrome-cdp`: launches or attaches to a Chrome-family browser over Chrome DevTools Protocol.
+- `chrome-cdp`: launches or attaches to a Chrome-family browser over Chrome DevTools Protocol. This is the default and recommended backend.
+- `electron`: embedded windows managed by Agentify Desktop. Use this only as an explicit fallback.
 
-Use Chrome CDP when SSO providers fight embedded Electron login:
+Chrome CDP is the default because SSO providers commonly block embedded Electron login:
 
 ```bash
-AGENTIFY_DESKTOP_BROWSER_BACKEND=chrome-cdp npx @agentify/desktop
+npx @agentify/desktop
 ```
 
 Optional Chrome CDP settings:
@@ -243,6 +243,7 @@ You can also pass GUI flags:
 
 ```bash
 npx @agentify/desktop gui --browser-backend chrome-cdp
+npx @agentify/desktop gui --browser-backend electron
 npx @agentify/desktop gui --chrome-debug-port 9333
 ```
 

--- a/bin/agentify-desktop.mjs
+++ b/bin/agentify-desktop.mjs
@@ -60,7 +60,8 @@ async function runMcp(args) {
 function runGui(args) {
   const child = spawn(electronBin(), [packageRoot, ...args], {
     stdio: 'inherit',
-    env: process.env
+    env: process.env,
+    shell: process.platform === 'win32'
   });
   child.on('error', (err) => {
     console.error(`agentify-desktop failed to start: ${err.message}`);

--- a/browser-backend.mjs
+++ b/browser-backend.mjs
@@ -1,11 +1,11 @@
-export const SUPPORTED_BROWSER_BACKENDS = ['electron', 'chrome-cdp'];
+export const SUPPORTED_BROWSER_BACKENDS = ['chrome-cdp', 'electron'];
 
 export function normalizeBrowserBackend(value) {
   const raw = String(value || '').trim().toLowerCase();
-  if (!raw) return 'electron';
+  if (!raw) return 'chrome-cdp';
   if (raw === 'chrome' || raw === 'chrome_cdp' || raw === 'cdp') return 'chrome-cdp';
   if (SUPPORTED_BROWSER_BACKENDS.includes(raw)) return raw;
-  return 'electron';
+  return 'chrome-cdp';
 }
 
 export function resolveBrowserBackend({

--- a/chatgpt-controller.mjs
+++ b/chatgpt-controller.mjs
@@ -841,12 +841,24 @@ export class ChatGPTController {
     const assistantSel = JSON.stringify(this.selectors.assistantMessage);
     const out = await this.#eval(`(async () => {
       const nodes = Array.from(document.querySelectorAll(${assistantSel}));
-      const last = nodes[nodes.length - 1];
+      const last = nodes[nodes.length - 1] || document.querySelector('main') || document.body;
       if (!last) return [];
-      const imgs = Array.from(last.querySelectorAll('img'));
-      const canvases = Array.from(last.querySelectorAll('canvas'));
       const results = [];
-      for (const img of imgs.slice(0, ${maxImages})) {
+      const seen = new Set();
+      const push = (item) => {
+        const key = String(item.dataUrl || item.src || '');
+        if (!key || seen.has(key)) return;
+        seen.add(key);
+        results.push(item);
+      };
+      const collectRoot = (root) => Array.from(root.querySelectorAll('img')).filter((img) => {
+        const r = img.getBoundingClientRect();
+        const src = img.currentSrc || img.src || '';
+        return src && r.width >= 64 && r.height >= 64;
+      });
+      const imgs = [...collectRoot(last), ...collectRoot(document.querySelector('main') || document.body)];
+      for (const img of imgs) {
+        if (results.length >= ${maxImages}) break;
         const src = img.currentSrc || img.src || '';
         const alt = img.alt || '';
         if (!src) continue;
@@ -854,42 +866,55 @@ export class ChatGPTController {
           try {
             const r = await fetch(src);
             const b = await r.blob();
-            if (b.size > 15 * 1024 * 1024) { results.push({ src, alt }); continue; }
+            if (b.size > 15 * 1024 * 1024) { push({ src, alt }); continue; }
             const dataUrl = await new Promise((resolve, reject) => {
               const fr = new FileReader();
               fr.onerror = () => reject(new Error('file_reader_error'));
               fr.onload = () => resolve(String(fr.result || ''));
               fr.readAsDataURL(b);
             });
-            results.push({ src, alt, dataUrl });
+            push({ src, alt, dataUrl });
             continue;
           } catch {}
         }
-        results.push({ src, alt });
+        push({ src, alt });
       }
 
+      const canvases = Array.from(last.querySelectorAll('canvas'));
       for (let i = 0; i < canvases.length && results.length < ${maxImages}; i++) {
         const c = canvases[i];
         try {
           const dataUrl = c.toDataURL('image/png');
           if (dataUrl && dataUrl.startsWith('data:image/')) {
-            results.push({ src: 'canvas:' + (i + 1), alt: 'canvas', dataUrl });
+            push({ src: 'canvas:' + (i + 1), alt: 'canvas', dataUrl });
           }
         } catch {}
       }
 
-      // Background-image urls (rare but possible)
       if (results.length < ${maxImages}) {
-        const bgEls = Array.from(last.querySelectorAll('*')).filter(el => {
+        const bgEls = Array.from((document.querySelector('main') || last).querySelectorAll('*')).filter(el => {
           const s = getComputedStyle(el);
-          return s && s.backgroundImage && s.backgroundImage.includes('url(');
+          const r = el.getBoundingClientRect();
+          return s && s.backgroundImage && s.backgroundImage.includes('url(') && r.width >= 64 && r.height >= 64;
         }).slice(0, 50);
         for (const el of bgEls) {
           if (results.length >= ${maxImages}) break;
           const s = getComputedStyle(el).backgroundImage || '';
           const m = s.match(/url\\([\"']?([^\"')]+)[\"']?\\)/i);
           const src = m?.[1] || '';
-          if (src && (src.startsWith('http://') || src.startsWith('https://'))) results.push({ src, alt: 'background-image' });
+          if (src && (src.startsWith('http://') || src.startsWith('https://') || src.startsWith('blob:'))) push({ src, alt: 'background-image' });
+        }
+      }
+
+      if (results.length < ${maxImages}) {
+        const links = Array.from(document.querySelectorAll('a[href]')).filter((a) => {
+          const href = String(a.href || '');
+          return /\\.(png|jpe?g|webp)(\\?|#|$)/i.test(href) || /download|image|generated/i.test((a.textContent || '') + ' ' + (a.getAttribute('aria-label') || ''));
+        });
+        for (const a of links) {
+          if (results.length >= ${maxImages}) break;
+          const src = String(a.href || '');
+          if (src.startsWith('http://') || src.startsWith('https://') || src.startsWith('blob:')) push({ src, alt: (a.textContent || '').trim() || 'link' });
         }
       }
       return results;
@@ -927,7 +952,7 @@ export class ChatGPTController {
 
       const ext =
         mime?.includes('png') ? 'png' : mime?.includes('jpeg') || mime?.includes('jpg') ? 'jpg' : mime?.includes('webp') ? 'webp' : 'bin';
-      const name = `chatgpt-${Date.now()}-${String(i + 1).padStart(2, '0')}.${ext}`;
+      const name = `agentify-${Date.now()}-${String(i + 1).padStart(2, '0')}.${ext}`;
       const file = path.join(outDir, name);
       await fs.writeFile(file, buf);
       saved.push({ path: file, alt: img.alt || '', mime: mime || null, source: img.src || null });

--- a/chrome-cdp-backend.mjs
+++ b/chrome-cdp-backend.mjs
@@ -551,7 +551,8 @@ export class ChromeCdpBrowserBackend {
         startUrl: 'about:blank'
       });
       this.chromeProcess = spawn(executable, args, {
-        stdio: 'ignore'
+        stdio: 'ignore',
+        shell: process.platform === 'win32'
       });
       this.chromeProcess.unref?.();
 

--- a/http-api.mjs
+++ b/http-api.mjs
@@ -187,10 +187,12 @@ async function resolveTab({ tabs, defaultTabId, body, url, showTabsByDefault = f
   const vendor = explicitVendor || defaultVendor(vendors);
   if (tabId) return tabId;
   if (key) {
+    const existing = (tabs.listTabs?.() || []).find((t) => t?.key === key);
+    if (existing?.id) {
+      if (explicitVendor && !listedTabMatchesVendor(existing, explicitVendor)) throw new Error('key_vendor_mismatch');
+      return existing.id;
+    }
     if (!createIfMissing) {
-      const existing = (tabs.listTabs?.() || []).find((t) => t?.key === key);
-      if (explicitVendor && existing?.id && !listedTabMatchesVendor(existing, explicitVendor)) throw new Error('key_vendor_mismatch');
-      if (existing?.id) return existing.id;
       throw new Error('tab_not_found');
     }
     return await tabs.ensureTab({

--- a/mcp-lib.mjs
+++ b/mcp-lib.mjs
@@ -67,7 +67,8 @@ export async function ensureDesktopRunning({
   fetchImpl = fetch,
   spawnImpl = spawn,
   timeoutMs = 30_000,
-  showTabs = false
+  showTabs = false,
+  platform = process.platform
 }) {
   const conn = await loadConnection({ stateDir });
   if (conn) {
@@ -83,7 +84,7 @@ export async function ensureDesktopRunning({
     __dirname,
     'node_modules',
     '.bin',
-    process.platform === 'win32' ? 'electron.cmd' : 'electron'
+    platform === 'win32' ? 'electron.cmd' : 'electron'
   );
   const entry = path.join(__dirname, 'main.mjs');
   const usingCustomSpawn = spawnImpl !== spawn;
@@ -104,7 +105,8 @@ export async function ensureDesktopRunning({
       ...process.env,
       AGENTIFY_DESKTOP_STATE_DIR: stateDir,
       ...(showTabs ? { AGENTIFY_DESKTOP_SHOW_TABS: 'true' } : {})
-    }
+    },
+    shell: platform === 'win32'
   })?.unref?.();
 
   const start = Date.now();

--- a/mcp-server.mjs
+++ b/mcp-server.mjs
@@ -31,13 +31,13 @@ registerTool(
   'agentify_query',
   {
     description:
-      'Send a prompt to the local Agentify Desktop session (ChatGPT web) and return the latest assistant response. If a CAPTCHA/login challenge appears, the desktop window will ask for user intervention and resume automatically.',
+      'Send a prompt to a local Agentify Desktop browser session and return the latest assistant response. If a CAPTCHA/login challenge appears, the browser window will ask for user intervention and resume automatically.',
     inputSchema: {
       model: z.string().optional().describe('Target model/provider hint (e.g., "chatgpt").'),
       tabId: z.string().optional().describe('Tab/session id to use (for parallel jobs).'),
       key: z.string().optional().describe('Stable tab key (e.g., project name); creates a tab if missing.'),
       bundleName: z.string().optional().describe('Named context bundle to merge into this query before sending.'),
-      prompt: z.string().describe('Prompt to send to ChatGPT.'),
+      prompt: z.string().describe('Prompt to send to the selected AI web UI.'),
       promptPrefix: z.string().optional().describe('Optional reusable instruction block prepended before packed context and prompt.'),
       attachments: z.array(z.string()).optional().describe('Local file paths to upload before sending the prompt.'),
       contextPaths: z.array(z.string()).optional().describe('Local files/folders to pack into the prompt and/or attach automatically.'),
@@ -247,12 +247,12 @@ registerTool(
   'agentify_image_gen',
   {
     description:
-      'Generate images via ChatGPT web UI (best-effort): sends the prompt, then downloads any images from the latest assistant message to a local folder and returns file paths.',
+      'Generate images via the selected AI web UI (best-effort): sends the prompt, then downloads images from the page to a local folder and returns file paths.',
     inputSchema: {
       model: z.string().optional().describe('Target model/provider hint (e.g., "chatgpt").'),
       tabId: z.string().optional().describe('Tab/session id to use.'),
       key: z.string().optional().describe('Stable tab key; creates a tab if missing.'),
-      prompt: z.string().describe('Prompt to send to ChatGPT for image generation.'),
+      prompt: z.string().describe('Prompt to send for image generation.'),
       timeoutMs: z.number().optional().describe('Maximum time to wait for completion.'),
       maxImages: z.number().optional().describe('Maximum images to download.')
     }

--- a/state.mjs
+++ b/state.mjs
@@ -28,7 +28,7 @@ export function settingsPath(stateDir = defaultStateDir()) {
 
 export function defaultSettings() {
   return {
-    browserBackend: 'electron',
+    browserBackend: 'chrome-cdp',
     chromeDebugPort: 9222,
     chromeExecutablePath: null,
     chromeProfileMode: 'isolated',

--- a/tests/browser-backend.test.mjs
+++ b/tests/browser-backend.test.mjs
@@ -15,7 +15,8 @@ test('browser-backend: normalizes aliases', () => {
   assert.equal(normalizeBrowserBackend('chrome'), 'chrome-cdp');
   assert.equal(normalizeBrowserBackend('cdp'), 'chrome-cdp');
   assert.equal(normalizeBrowserBackend('electron'), 'electron');
-  assert.equal(normalizeBrowserBackend('unknown'), 'electron');
+  assert.equal(normalizeBrowserBackend('unknown'), 'chrome-cdp');
+  assert.equal(normalizeBrowserBackend(''), 'chrome-cdp');
 });
 
 test('browser-backend: argv overrides env and settings', () => {

--- a/tests/http-api.test.mjs
+++ b/tests/http-api.test.mjs
@@ -814,6 +814,64 @@ test('http-api: query with keyed tab uses default vendor metadata when no model 
   assert.equal(ensuredArgs.url, 'https://chatgpt.com/');
 });
 
+test('http-api: query with existing keyed vendor tab does not default to ChatGPT', async (t) => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentify-http-existing-vendor-key-'));
+  let ensureCalls = 0;
+  const controller = {
+    runExclusive: async (fn) => await fn(),
+    query: async () => ({ text: 'ok', codeBlocks: [], meta: {} })
+  };
+  const tabs = {
+    listTabs: () => [{ id: 't-perplexity', key: 'perplexity', vendorId: 'perplexity', vendorName: 'Perplexity', url: 'https://www.perplexity.ai/' }],
+    ensureTab: async () => {
+      ensureCalls += 1;
+      return 'unexpected';
+    },
+    createTab: async () => 'unexpected',
+    closeTab: async () => true,
+    getControllerById: (id) => {
+      assert.equal(id, 't-perplexity');
+      return controller;
+    }
+  };
+  const server = await startHttpApi({
+    port: 0,
+    token: 'secret',
+    tabs,
+    defaultTabId: 't0',
+    vendors: [
+      { id: 'chatgpt', name: 'ChatGPT', url: 'https://chatgpt.com/' },
+      { id: 'perplexity', name: 'Perplexity', url: 'https://www.perplexity.ai/' }
+    ],
+    serverId: 'sid-test',
+    stateDir: dir,
+    getStatus: async () => ({ ok: true })
+  });
+  t.after(() => server.close());
+  const port = server.address().port;
+
+  const reused = await req({
+    port,
+    token: 'secret',
+    method: 'POST',
+    pth: '/query',
+    body: { key: 'perplexity', prompt: 'hi' }
+  });
+  assert.equal(reused.res.status, 200);
+  assert.equal(reused.data.tabId, 't-perplexity');
+  assert.equal(ensureCalls, 0);
+
+  const mismatch = await req({
+    port,
+    token: 'secret',
+    method: 'POST',
+    pth: '/query',
+    body: { key: 'perplexity', vendorId: 'chatgpt', prompt: 'hi' }
+  });
+  assert.equal(mismatch.res.status, 409);
+  assert.equal(mismatch.data.error, 'key_vendor_mismatch');
+});
+
 test('http-api: bundle save/list/get/delete work', async (t) => {
   const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agentify-http-bundles-'));
   const tabs = {

--- a/tests/mcp-lib.test.mjs
+++ b/tests/mcp-lib.test.mjs
@@ -104,6 +104,31 @@ test('mcp-lib: ensureDesktopRunning spawns if serverId mismatches and then recov
   assert.equal(conn.serverId, 'sid-new');
 });
 
+test('mcp-lib: Windows spawn uses shell for electron.cmd', async () => {
+  const dir = await tempDir();
+  const token = 't';
+  await ensureToken(dir);
+  await fs.writeFile(path.join(dir, 'token.txt'), `${token}\n`, 'utf8');
+  await writeState({ ok: true, port: 12345, serverId: 'sid-old' }, dir);
+
+  let fetchServerId = 'sid-wrong';
+  let sawShell = false;
+  const conn = await ensureDesktopRunning({
+    stateDir: dir,
+    fetchImpl: makeFetch({ getServerId: () => fetchServerId, acceptToken: token }),
+    platform: 'win32',
+    spawnImpl: (_cmd, _args, opts) => {
+      sawShell = opts?.shell === true;
+      fetchServerId = 'sid-new';
+      void writeState({ ok: true, port: 12345, serverId: 'sid-new' }, dir);
+      return { unref() {} };
+    },
+    timeoutMs: 3000
+  });
+  assert.equal(conn.serverId, 'sid-new');
+  assert.equal(sawShell, true);
+});
+
 test('mcp-lib: ensureDesktopRunning resolves bundled electron relative to desktop package, not cwd', async () => {
   const dir = await tempDir();
   const token = 't';

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -31,7 +31,7 @@ test('state: writeToken overrides existing', async () => {
 test('state: normalizeSettings defaults allowAuthPopups to true', () => {
   const s = normalizeSettings({});
   assert.equal(s.allowAuthPopups, true);
-  assert.equal(s.browserBackend, 'electron');
+  assert.equal(s.browserBackend, 'chrome-cdp');
   assert.equal(s.chromeDebugPort, 9222);
   assert.equal(s.chromeProfileMode, 'isolated');
   assert.equal(s.chromeProfileName, 'Default');


### PR DESCRIPTION
## Summary
- make Chrome CDP the default backend instead of Electron, keeping Electron as an explicit fallback
- reuse existing keyed vendor tabs when `model`/`vendorId` is omitted, preventing Perplexity key/vendor mismatches
- add Windows shell spawning for Electron launcher paths
- broaden image extraction for Grok-like generated image pages
- update docs and regression tests

## Validation
- `npm test` in the working checkout: 34/34 passing
- clean `origin/main` patch tree: relevant HTTP/browser/state tests passed; full temp run was blocked by temp checkout environment/path artifacts for Electron package resolution and an existing checkout-path assertion
- `git diff --check origin/main fe0a47de8392c7e8c6a8e7c22d8f6f603b423acd` passed
