### PR TITLE
Prepare Agentify Desktop 0.2.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ yarn-error.log*
 # Local planning notes are not part of the public package/repo.
 TODO_*.md
 !TODO_fix-sso-popup-hardening.md
+private-workflows/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 0.2.0 - 2026-05-17
+
+### Added
+- Public release notes and package metadata for the 0.2.0 npm release.
+- README prompt examples for common MCP workflows after Agentify is installed.
+- Explicit `.gitignore` protection for local-only private workflows.
+
+### Changed
+- README examples now focus on generic browser automation, artifact saving, context packing, and multi-vendor review workflows.
+- Removed private/domain-specific workflow language from public docs and package guidance.
+- Updated package version from 0.1.2 to 0.2.0.
+
+### Verified
+- Public package dry-run excludes private workflows.
+- Public source scan excludes private workflow tool and module references.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Agentify Desktop is a local control center for AI web sessions. It lets MCP-capa
 - Packs local repo/file context into prompts when requested.
 - Saves generated images/files locally so they can be reused in follow-up prompts.
 
+## Example Prompts After MCP Setup
+
+Once Agentify Desktop is running and registered with your MCP client, you can ask for workflows like:
+
+- “Use Agentify with key `repo-triage` to ask ChatGPT for a second opinion on this bug, then compare its answer with your own analysis.”
+- “Open a Perplexity tab with key `research-auth-flow` and research current OAuth best practices for desktop apps.”
+- “Send this implementation plan to Claude in a separate Agentify tab and summarize any risks it finds.”
+- “Use Agentify to generate three UI concept images, save the images as artifacts, and return the local file paths.”
+- “Open Grok and ChatGPT in separate Agentify tabs, ask both to review this API design, then compare the tradeoffs.”
+- “Pack this repo into context, ask ChatGPT to identify risky files, and save the conversation under a stable tab key for follow-ups.”
+- “Read the current ChatGPT page through Agentify and turn the conversation into actionable TODOs.”
+
 ## Requirements
 
 - Node.js 20 or newer
@@ -46,7 +58,7 @@ npm install -g @agentify/desktop
 agentify-desktop
 ```
 
-If you want the older repo-clone and local source workflow, use [DEVELOPMENT_FROM_SOURCE.md](/Users/upwiz/crowd4gpt.com/desktop/DEVELOPMENT_FROM_SOURCE.md).
+If you want the older repo-clone and local source workflow, use [DEVELOPMENT_FROM_SOURCE.md](DEVELOPMENT_FROM_SOURCE.md).
 
 ## MCP Server
 
@@ -154,8 +166,8 @@ Generate an image or file in a stable tab:
 {
   "tool": "agentify_query",
   "arguments": {
-    "key": "sprite-lab",
-    "prompt": "Generate 3 simple 2D pixel-art robot sprite variations on transparent backgrounds."
+    "key": "ui-concepts",
+    "prompt": "Generate 3 clean UI concept images for a compact desktop developer tool. Keep backgrounds neutral and avoid text."
   }
 }
 ```
@@ -166,7 +178,7 @@ Save the generated images locally:
 {
   "tool": "agentify_save_artifacts",
   "arguments": {
-    "key": "sprite-lab",
+    "key": "ui-concepts",
     "mode": "images",
     "maxImages": 3
   }
@@ -179,9 +191,9 @@ Reattach one of the returned file paths in a follow-up:
 {
   "tool": "agentify_query",
   "arguments": {
-    "key": "sprite-lab",
-    "prompt": "Use the attached sprite and make a damaged version with one broken eye.",
-    "attachments": ["/absolute/path/to/sprite.png"]
+    "key": "ui-concepts",
+    "prompt": "Use the attached concept image and create a more minimal variant with stronger contrast.",
+    "attachments": ["/absolute/path/to/concept.png"]
   }
 }
 ```
@@ -284,7 +296,7 @@ Anyone with access to your machine account may be able to access local session d
 
 ## Development From Source
 
-Source checkout, quickstart script usage, local build commands, and source-only debugging notes live in [DEVELOPMENT_FROM_SOURCE.md](/Users/upwiz/crowd4gpt.com/desktop/DEVELOPMENT_FROM_SOURCE.md).
+Source checkout, quickstart script usage, local build commands, and source-only debugging notes live in [DEVELOPMENT_FROM_SOURCE.md](DEVELOPMENT_FROM_SOURCE.md).
 
 ## Package Commands
 
@@ -304,4 +316,4 @@ npx -p @agentify/desktop agentify-desktop-mcp
 
 ## License And Trademarks
 
-The code is licensed under `MPL-2.0`. Agentify trademarks and branding are not included in that license. See [TRADEMARKS.md](/Users/upwiz/crowd4gpt.com/desktop/TRADEMARKS.md).
+The code is licensed under `MPL-2.0`. Agentify trademarks and branding are not included in that license. See [TRADEMARKS.md](TRADEMARKS.md).

--- a/mcp-server.mjs
+++ b/mcp-server.mjs
@@ -156,7 +156,7 @@ registerTool(
   'agentify_ensure_ready',
   {
     description:
-      'Wait until ChatGPT is ready for input (e.g., after login/CAPTCHA). Triggers local user handoff if needed and resumes when the prompt textarea is visible.',
+      'Wait until the selected AI web UI is ready for input (e.g., after login/CAPTCHA). Triggers local user handoff if needed and resumes when the prompt textarea is visible.',
     inputSchema: {
       model: z.string().optional().describe('Target model/provider hint (e.g., "chatgpt").'),
       tabId: z.string().optional().describe('Tab/session id to use.'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentify/desktop",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentify/desktop",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentify/desktop",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Agentify Desktop control center and MCP server for local AI web sessions",
   "license": "MPL-2.0",
   "type": "module",
@@ -11,6 +11,7 @@
     "agentify-desktop-mcp": "bin/agentify-desktop.mjs"
   },
   "files": [
+    "CHANGELOG.md",
     "README.md",
     "SECURITY.md",
     "TRADEMARKS.md",

--- a/tests/mcp-lib.test.mjs
+++ b/tests/mcp-lib.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 
 import { ensureToken, writeState } from '../state.mjs';
 import { ensureDesktopRunning, requestJson } from '../mcp-lib.mjs';
@@ -155,8 +156,9 @@ test('mcp-lib: ensureDesktopRunning resolves bundled electron relative to deskto
     const conn = await ensureDesktopRunning({ stateDir: dir, fetchImpl, spawnImpl, timeoutMs: 3000 });
     assert.equal(conn.serverId, 'sid-new');
     assert.equal(path.isAbsolute(spawnedCmd), true);
-    assert.match(spawnedCmd, /desktop[\\/]+node_modules[\\/]+\.bin[\\/]+electron(?:\.cmd)?$/);
-    assert.equal(spawnedArgs?.[0]?.endsWith(path.join('desktop', 'main.mjs')), true);
+    const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+    assert.equal(spawnedCmd, path.join(packageRoot, 'node_modules', '.bin', process.platform === 'win32' ? 'electron.cmd' : 'electron'));
+    assert.equal(spawnedArgs?.[0], path.join(packageRoot, 'main.mjs'));
   } finally {
     process.chdir(originalCwd);
   }

--- a/ui/control-center.html
+++ b/ui/control-center.html
@@ -113,7 +113,7 @@
           <div class="grid">
             <label class="field">
               <div class="label">Folder name (optional)</div>
-              <input id="watchFolderName" type="text" placeholder="e.g. sprites" autocomplete="off" />
+              <input id="watchFolderName" type="text" placeholder="e.g. screenshots" autocomplete="off" />
             </label>
             <label class="field">
               <div class="label">Folder path</div>

--- a/ui/control-center.js
+++ b/ui/control-center.js
@@ -89,7 +89,7 @@ function hasApi(name) {
 async function callApi(name, args, { fallback = null, required = false } = {}) {
   const b = getBridge();
   if (typeof b?.[name] !== 'function') {
-    if (required) throw new Error(`missing_desktop_api:${name} (open Control Center inside Agentify Desktop, then restart)`);
+    if (required) throw new Error(`${name} is unavailable in this window. Restart Agentify Desktop after updating.`);
     return fallback;
   }
   try {


### PR DESCRIPTION
## Summary

Prepare the Agentify Desktop 0.2.0 release from current `main`.

- bump package and lockfile version to `0.2.0`
- add `CHANGELOG.md` for the release
- add README prompt examples after MCP setup
- remove public sprite/domain-specific examples from README
- add `private-workflows/` to `.gitignore` so internal workflows stay local-only
- clarify MCP readiness copy for multi-vendor AI web UIs
- make the stale desktop bridge error more actionable
- make the MCP bundled Electron path test robust outside a checkout named `desktop`

## Validation

- `npm test` passed: 162/162
- `git diff --check` passed
- `npm pack --dry-run --json` showed no `private-workflows/`, `workflows/game-assets`, `sprite-sheet-workflow`, or `agentify_sprite_sheet` package entries
- public source scan showed no private sprite workflow tool/module references outside ignored private files

## Note

I intentionally did not PR the earlier disconnected `codex/release-0.2.0` branch because it had no shared history with `main` and would have removed many current main-branch files. This branch is based directly on current `main`.
