### PR TITLE
Restore Control Center header controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.2.1 - 2026-05-17
+
+### Fixed
+- Restored the intended icon-only Control Center header controls for opening the default tab, watch folder, artifacts folder, state folder, and refresh.
+- Added the missing show/hide-all managed tabs toggle in the Control Center header.
+- Kept the Orchestrator UI hidden from the Control Center public surface.
+
+### Verified
+- Control Center script syntax check passed.
+- Public package dry-run excludes private workflows.
+
 ## 0.2.0 - 2026-05-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agentify/desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agentify/desktop",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agentify/desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Agentify Desktop control center and MCP server for local AI web sessions",
   "license": "MPL-2.0",
   "type": "module",

--- a/ui/control-center.css
+++ b/ui/control-center.css
@@ -54,6 +54,7 @@ body {
 }
 .iconOnlyHeaderBtn {
   min-width: 36px;
+  width: 36px;
   padding: 8px;
 }
 .headerBtnInner {
@@ -69,6 +70,15 @@ body {
 }
 .headerLabel {
   white-space: nowrap;
+}
+.iconShowTabs {
+  display: none;
+}
+.tabsAreHidden .iconHideTabs {
+  display: none;
+}
+.tabsAreHidden .iconShowTabs {
+  display: block;
 }
 .badge {
   display: inline-block;

--- a/ui/control-center.html
+++ b/ui/control-center.html
@@ -17,43 +17,51 @@
           </div>
         </div>
         <div class="actions">
-          <button id="btnShowDefault" class="btn secondary headerBtn" title="Open default tab">
+          <button id="btnToggleTabs" class="btn secondary headerBtn iconOnlyHeaderBtn" title="Hide all managed tabs" aria-label="Hide all managed tabs" aria-pressed="false">
+            <span class="headerBtnInner">
+              <svg class="headerIcon iconHideTabs" viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M1.5 8s2.4-4 6.5-4 6.5 4 6.5 4-2.4 4-6.5 4-6.5-4-6.5-4Z" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>
+                <path d="M3 13 13 3" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+              </svg>
+              <svg class="headerIcon iconShowTabs" viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M1.5 8s2.4-4 6.5-4 6.5 4 6.5 4-2.4 4-6.5 4-6.5-4-6.5-4Z" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>
+                <circle cx="8" cy="8" r="2.1" fill="none" stroke="currentColor" stroke-width="1.4"/>
+              </svg>
+            </span>
+          </button>
+          <button id="btnShowDefault" class="btn secondary headerBtn iconOnlyHeaderBtn" title="Open default tab" aria-label="Open default tab">
             <span class="headerBtnInner">
               <svg class="headerIcon" viewBox="0 0 16 16" aria-hidden="true">
                 <path d="M1.5 8s2.4-4 6.5-4 6.5 4 6.5 4-2.4 4-6.5 4-6.5-4-6.5-4Z" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>
                 <circle cx="8" cy="8" r="2.1" fill="none" stroke="currentColor" stroke-width="1.4"/>
               </svg>
-              <span class="headerLabel">Open default tab</span>
             </span>
           </button>
-          <button id="btnOpenWatch" class="btn secondary headerBtn" title="Open watch folder">
+          <button id="btnOpenWatch" class="btn secondary headerBtn iconOnlyHeaderBtn" title="Open watch folder" aria-label="Open watch folder">
             <span class="headerBtnInner">
               <svg class="headerIcon" viewBox="0 0 16 16" aria-hidden="true">
                 <path d="M1.8 4.5h4l1.3 1.6h7.1v5.9a1.2 1.2 0 0 1-1.2 1.2H3a1.2 1.2 0 0 1-1.2-1.2Z" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>
                 <path d="M5 8.3a2.6 2.6 0 0 0 2.6 2.6" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
                 <path d="M8.5 7.1a2.6 2.6 0 0 1 0 3.8" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
               </svg>
-              <span class="headerLabel">Watch</span>
             </span>
           </button>
-          <button id="btnOpenArtifacts" class="btn secondary headerBtn" title="Open artifacts folder">
+          <button id="btnOpenArtifacts" class="btn secondary headerBtn iconOnlyHeaderBtn" title="Open artifacts folder" aria-label="Open artifacts folder">
             <span class="headerBtnInner">
               <svg class="headerIcon" viewBox="0 0 16 16" aria-hidden="true">
                 <path d="M2.4 3.1h11.2v9.8H2.4z" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>
                 <path d="m4.2 10.7 2.3-2.6 1.8 1.9 1.3-1.5 2.2 2.2" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
                 <circle cx="5.6" cy="5.8" r="0.9" fill="currentColor"/>
               </svg>
-              <span class="headerLabel">Artifacts</span>
             </span>
           </button>
-          <button id="btnOpenState" class="btn secondary headerBtn" title="Open state folder">
+          <button id="btnOpenState" class="btn secondary headerBtn iconOnlyHeaderBtn" title="Open state folder" aria-label="Open state folder">
             <span class="headerBtnInner">
               <svg class="headerIcon" viewBox="0 0 16 16" aria-hidden="true">
                 <path d="M3 2.8h6.2l3 3v7.4H3z" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>
                 <path d="M9.2 2.8v3h3" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>
                 <path d="M5.2 9.2h4.9M5.2 11.3h4.1" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
               </svg>
-              <span class="headerLabel">State</span>
             </span>
           </button>
           <button id="btnRefresh" class="btn secondary headerBtn iconOnlyHeaderBtn" title="Refresh current view" aria-label="Refresh current view">

--- a/ui/control-center.js
+++ b/ui/control-center.js
@@ -149,6 +149,7 @@ let lastState = defaultState();
 let refreshInFlight = null;
 let lastRefreshAt = 0;
 let hasLiveUpdates = false;
+let tabsAreHidden = false;
 
 function tabSortWeight(tab, active, outcome) {
   if (active?.blocked) return 0;
@@ -158,6 +159,41 @@ function tabSortWeight(tab, active, outcome) {
   if (outcome?.status === 'stopped') return 4;
   if (outcome?.status === 'success') return 5;
   return tab?.protectedTab ? 7 : 6;
+}
+
+function updateTabsToggle(tabs = []) {
+  const btn = document.getElementById('btnToggleTabs');
+  if (!btn) return;
+  const hasTabs = Array.isArray(tabs) && tabs.length > 0;
+  const label = tabsAreHidden ? 'Show all managed tabs' : 'Hide all managed tabs';
+  btn.disabled = !hasTabs;
+  btn.title = hasTabs ? label : 'No managed tabs are currently open';
+  btn.setAttribute('aria-label', btn.title);
+  btn.setAttribute('aria-pressed', tabsAreHidden ? 'true' : 'false');
+  btn.classList.toggle('tabsAreHidden', tabsAreHidden);
+}
+
+async function setAllTabsVisible(visible) {
+  const tabs = Array.isArray(lastState.tabs) ? lastState.tabs : [];
+  if (!tabs.length) {
+    statusText('No managed tabs are currently open.');
+    return;
+  }
+  let changed = 0;
+  for (const tab of tabs) {
+    const tabId = tab?.id;
+    if (!tabId) continue;
+    try {
+      await callApi(visible ? 'showTab' : 'hideTab', { tabId }, { required: true });
+      changed += 1;
+    } catch (e) {
+      statusText(`${visible ? 'Show' : 'Hide'} all stopped at ${tab.name || tab.key || tab.id}: ${e?.message || String(e)}`);
+      break;
+    }
+  }
+  tabsAreHidden = !visible;
+  updateTabsToggle(tabs);
+  statusText(`${visible ? 'Showed' : 'Hid'} ${changed} managed tab${changed === 1 ? '' : 's'}.`);
 }
 
 async function refresh() {
@@ -185,6 +221,7 @@ async function refresh() {
     }
 
     const tabs = Array.isArray(lastState.tabs) ? lastState.tabs : [];
+    updateTabsToggle(tabs);
     const runtime = lastState.runtime || { inflightQueries: 0, activeQueries: [], lastOutcomes: [] };
     const activeQueries = Array.isArray(runtime.activeQueries) ? runtime.activeQueries : [];
     const lastOutcomes = Array.isArray(runtime.lastOutcomes) ? runtime.lastOutcomes : [];
@@ -444,6 +481,7 @@ async function main() {
   }
 
   el('btnRefresh').onclick = () => refresh().catch((e) => statusText(`Refresh failed: ${e?.message || String(e)}`));
+  el('btnToggleTabs').onclick = () => setAllTabsVisible(tabsAreHidden).catch((e) => statusText(`${tabsAreHidden ? 'Show' : 'Hide'} all failed: ${e?.message || String(e)}`));
   el('btnOpenState').onclick = async () => {
     try {
       await callApi('openStateDir', undefined, { required: true });


### PR DESCRIPTION
## Summary

Correct the 0.2.0 release by restoring the intended Control Center header controls.

- add the missing show/hide-all managed tabs toggle in the header
- make header controls icon-only for default tab, watch folder, artifacts folder, state folder, and refresh
- keep Orchestrator out of the public Control Center surface
- bump package version to 0.2.1 and document the corrective patch in CHANGELOG

## Validation

- `node --check ui/control-center.js`
- `git diff --check`
- `npm test` passed: 162/162
- `npm pack --dry-run --json` private workflow scan returned no matches
